### PR TITLE
add CCPP-C384 capability and additional changes for CCPP-Chem

### DIFF
--- a/FV3GFSwfm/rt_ccpp-chem/noent_ics.xml
+++ b/FV3GFSwfm/rt_ccpp-chem/noent_ics.xml
@@ -1,0 +1,387 @@
+<?xml version="1.0"?>
+<!DOCTYPE workflow [
+<!--
+	PROGRAM
+		Main workflow manager for Forecast only Global Forecast System
+
+	AUTHOR:
+		Rahul Mahajan
+		rahul.mahajan@noaa.gov
+
+	NOTES:
+		This workflow was automatically generated at 2021-04-11 13:25:05.897628
+	--><!-- Experiment parameters such as name, cycle, resolution --><!ENTITY PSLOT "rt_ccpp-chem">
+<!ENTITY CDUMP "gfs">
+<!ENTITY CASE "C384">
+<!ENTITY COMPONENT "atmos">
+<!-- Experiment parameters such as starting, ending dates --><!ENTITY SDATE "202103230000">
+<!ENTITY EDATE "203001100000">
+<!ENTITY INTERVAL "24:00:00">
+<!-- Run Envrionment --><!ENTITY RUN_ENVIR "emc">
+<!-- Experiment related directories --><!ENTITY EXPDIR "/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp-chem">
+<!ENTITY ROTDIR "/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem">
+<!ENTITY ICSDIR "/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS">
+<!ENTITY RUNDIR "/scratch1/BMC/gsd-fv3/NCEPDEV/stmp3/rtfim/RUNDIRS/rt_ccpp-chem">
+<!ENTITY EMCDIR "/scratch1/NCEPDEV/rstprod/com/gfs/prod">
+<!ENTITY PUBDIR "/scratch2/BMC/public/data/grids/gfs/anl/netcdf">
+<!ENTITY RETRODIR "/scratch1/BMC/gsd-fv3-dev/GFS_RETRO_NETCDF/">
+<!ENTITY GFSDIR "/ESRL/BMC/fdr/Permanent">
+<!ENTITY EMIDIR "/scratch2/BMC/public/data/grids/sdsu/emissions">
+<!ENTITY ARCEMI "/scratch2/BMC/gsd-fv3-dev/Judy.K.Henderson/sdsu_emissions">
+<!-- Directories for driving the workflow --><!ENTITY HOMEgfs "/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem">
+<!ENTITY JOBS_DIR "/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/jobs/rocoto">
+<!-- Machine related entities --><!ENTITY ACCOUNT "gsd-fv3">
+<!ENTITY QUEUE "batch">
+<!ENTITY QUEUE_ARCH "service">
+<!ENTITY SCHEDULER "slurm">
+<!-- Toggle HPSS archiving --><!ENTITY ARCHIVE_TO_HPSS "YES">
+<!-- ROCOTO parameters that control workflow --><!ENTITY CYCLETHROTTLE "2">
+<!ENTITY TASKTHROTTLE "25">
+<!ENTITY MAXTRIES "2">
+<!-- BEGIN: Resource requirements for the workflow --><!ENTITY QUEUE_GETIC_GFS "&QUEUE;">
+<!ENTITY WALLTIME_GETIC_GFS "00:30:00">
+<!ENTITY RESOURCES_GETIC_GFS "<nodes>1:ppn=1</nodes>">
+<!ENTITY MEMORY_GETIC_GFS "">
+<!ENTITY NATIVE_GETIC_GFS "--export=NONE">
+<!ENTITY QUEUE_FV3IC_GFS "&QUEUE;">
+<!ENTITY WALLTIME_FV3IC_GFS "00:30:00">
+<!ENTITY RESOURCES_FV3IC_GFS "<nodes>4:ppn=6:tpp=1</nodes>">
+<!ENTITY NATIVE_FV3IC_GFS "--export=NONE">
+<!ENTITY QUEUE_REGRID "&QUEUE;">
+<!ENTITY WALLTIME_REGRID "00:30:00">
+<!ENTITY RESOURCES_REGRID "<nodes>1:ppn=2</nodes>">
+<!ENTITY MEMORY_REGRID "">
+<!ENTITY NATIVE_REGRID "--export=NONE">
+<!ENTITY QUEUE_CALCINC "&QUEUE;">
+<!ENTITY WALLTIME_CALCINC "00:30:00">
+<!ENTITY RESOURCES_CALCINC "<nodes>1:ppn=2</nodes>">
+<!ENTITY MEMORY_CALCINC "">
+<!ENTITY NATIVE_CALCINC "--export=NONE">
+<!ENTITY QUEUE_PREP_CHEM_SRC "&QUEUE;">
+<!ENTITY WALLTIME_PREP_CHEM_SRC "00:15:00">
+<!ENTITY RESOURCES_PREP_CHEM_SRC "<nodes>1:ppn=2</nodes>">
+<!ENTITY MEMORY_PREP_CHEM_SRC "">
+<!ENTITY NATIVE_PREP_CHEM_SRC "--export=NONE">
+<!ENTITY QUEUE_FCST_GFS "&QUEUE;">
+<!ENTITY WALLTIME_FCST_GFS "08:00:00">
+<!ENTITY RESOURCES_FCST_GFS "<nodes>8:ppn=40:tpp=1</nodes>">
+<!ENTITY NATIVE_FCST_GFS "--export=NONE">
+<!ENTITY QUEUE_POST_GFS "&QUEUE;">
+<!ENTITY WALLTIME_POST_GFS "00:30:00">
+<!ENTITY RESOURCES_POST_GFS "<nodes>4:ppn=12:tpp=1</nodes>">
+<!ENTITY NATIVE_POST_GFS "--export=NONE">
+<!ENTITY QUEUE_ARCH_GFS "&QUEUE;">
+<!ENTITY WALLTIME_ARCH_GFS "06:00:00">
+<!ENTITY RESOURCES_ARCH_GFS "<nodes>1:ppn=1:tpp=1</nodes>">
+<!ENTITY MEMORY_ARCH_GFS "2048M">
+<!ENTITY NATIVE_ARCH_GFS "--export=NONE">
+<!-- END: Resource requirements for the workflow -->]>
+<workflow realtime="T" scheduler="slurm" cyclethrottle="2" taskthrottle="25">
+
+	<log verbosity="10"><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp-chem/logs/@Y@m@d@H.log</cyclestr></log>
+
+	<!-- Define the cycles -->
+	<cycledef group="gfs">202103230000 203001100000 24:00:00</cycledef>
+
+<task name="gfsgetic" cycledefs="gfs" maxtries="2">
+	<command>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/jobs/rocoto/getic.sh</command>
+
+	<jobname><cyclestr>rt_ccpp-chem_gfsgetic_@H</cyclestr></jobname>
+	<account>gsd-fv3</account>
+	<queue>batch</queue>
+	<nodes>1:ppn=1</nodes>
+	<walltime>00:30:00</walltime>
+	<native>--export=NONE</native>
+
+	<join><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem/logs/@Y@m@d@H/gfsgetic.log</cyclestr></join>
+
+	<envar><name>RUN_ENVIR</name><value>emc</value></envar>
+	<envar><name>HOMEgfs</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem</value></envar>  
+	<envar><name>EXPDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp-chem</value></envar>
+	<envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+	<envar><name>CDUMP</name><value>gfs</value></envar>
+        <envar><name>COMPONENT</name><value>atmos</value></envar>
+	<envar><name>ICSDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS</value></envar>
+        <envar><name>EMCDIR</name><value>/scratch1/NCEPDEV/rstprod/com/gfs/prod</value></envar>
+	<envar><name>PUBDIR</name><value>/scratch2/BMC/public/data/grids/gfs/anl/netcdf</value></envar>
+	<envar><name>RETRODIR</name><value>/scratch1/BMC/gsd-fv3-dev/GFS_RETRO_NETCDF/</value></envar>
+	<envar><name>GFSDIR</name><value>/ESRL/BMC/fdr/Permanent</value></envar>
+	<envar><name>ROTDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem</value></envar>
+
+	<dependency>
+             <or>
+               <and>
+                 <datadep><cyclestr>/scratch2/BMC/public/data/grids/gfs/anl/netcdf/@y@j@H00.gfs.t@Hz.atmanl.nemsio</cyclestr></datadep>
+                 <datadep><cyclestr>/scratch2/BMC/public/data/grids/gfs/anl/netcdf/@y@j@H00.gfs.t@Hz.sfcanl.nemsio</cyclestr></datadep>
+               </and>
+                <!--  JKH -->
+               <and>
+                 <datadep><cyclestr>/scratch1/BMC/gsd-fv3-dev/GFS_RETRO_NETCDF//gfs.@Y@m@d/@H/atmos/gfs.t@Hz.atmanl.nc</cyclestr></datadep>
+                 <datadep><cyclestr>/scratch1/BMC/gsd-fv3-dev/GFS_RETRO_NETCDF//gfs.@Y@m@d/@H/atmos/gfs.t@Hz.sfcanl.nc</cyclestr></datadep>
+               </and>
+                <!--  JKH -->
+               <and>
+                 <datadep><cyclestr>/scratch1/BMC/gsd-fv3-dev/GFS_RETRO_NETCDF//@y@j@H00.gfs.t@Hz.atmanl.nc</cyclestr></datadep>
+                 <datadep><cyclestr>/scratch1/BMC/gsd-fv3-dev/GFS_RETRO_NETCDF//@y@j@H00.gfs.t@Hz.sfcanl.nc</cyclestr></datadep>
+               </and>
+             </or>
+	</dependency>
+</task>
+
+<task name="gfsfv3ic" cycledefs="gfs" maxtries="2">
+
+	<command>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/jobs/rocoto/fv3ic.sh</command>
+
+	<jobname><cyclestr>rt_ccpp-chem_gfsfv3ic_@H</cyclestr></jobname>
+	<account>gsd-fv3</account>
+	<queue>batch</queue>
+	<nodes>4:ppn=6:tpp=1</nodes>
+	<walltime>00:30:00</walltime>
+	<native>--export=NONE</native>
+
+	<join><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem/logs/@Y@m@d@H/gfsfv3ic.log</cyclestr></join>
+
+	<envar><name>RUN_ENVIR</name><value>emc</value></envar>
+	<envar><name>HOMEgfs</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem</value></envar>
+	<envar><name>EXPDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp-chem</value></envar>
+	<envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+	<envar><name>CDUMP</name><value>gfs</value></envar>
+	<envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+	<envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+	<envar><name>ROTDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem</value></envar>
+
+	<dependency>
+		<and>
+			<or>
+				<and>
+					<datadep><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS/@Y@m@d@H/gfs/gfs.t@Hz.atmanl.nemsio</cyclestr></datadep>
+					<datadep><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS/@Y@m@d@H/gfs/gfs.t@Hz.sfcanl.nemsio</cyclestr></datadep>
+				</and>
+				<and>
+					<datadep><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS/@Y@m@d@H/gfs/gfs.t@Hz.atmanl.nc</cyclestr></datadep>
+					<datadep><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS/@Y@m@d@H/gfs/gfs.t@Hz.sfcanl.nc</cyclestr></datadep>
+				</and>
+				<and>
+					<datadep><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS/@Y@m@d@H/gfs/siganl.gfs.@Y@m@d@H</cyclestr></datadep>
+					<datadep><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS/@Y@m@d@H/gfs/sfcanl.gfs.@Y@m@d@H</cyclestr></datadep>
+				</and>
+			</or>
+			<not>
+				<and>
+					<datadep><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS/@Y@m@d@H/gfs/C384/INPUT/gfs_data.tile6.nc</cyclestr></datadep>
+					<datadep><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS/@Y@m@d@H/gfs/C384/INPUT/sfc_data.tile6.nc</cyclestr></datadep>
+				</and>
+			</not>
+		</and>
+	</dependency>
+
+</task>
+<task name="regrid" cycledefs="gfs" maxtries="2">
+
+        <command>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/jobs/rocoto/regrid.sh</command>
+
+        <jobname><cyclestr>rt_ccpp-chem_regrid_@H</cyclestr></jobname>
+        <account>gsd-fv3</account>
+        <queue>batch</queue>
+        <nodes>1:ppn=2</nodes>
+        <walltime>00:30:00</walltime>
+        <native>--export=NONE</native>
+        <join><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem/logs/@Y@m@d@H/regrid.log</cyclestr></join>
+
+        <envar><name>RUN_ENVIR</name><value>emc</value></envar>
+        <envar><name>HOMEgfs</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem</value></envar>
+        <envar><name>EXPDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp-chem</value></envar>
+        <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+        <envar><name>OUTDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem</value></envar>
+        <envar><name>CDUMP</name><value>gfs</value></envar>
+        <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+        <envar><name>SYEAR</name><value><cyclestr>@Y</cyclestr></value></envar>
+        <envar><name>SMONTH</name><value><cyclestr>@m</cyclestr></value></envar>
+        <envar><name>SDAY</name><value><cyclestr>@d</cyclestr></value></envar>
+        <envar><name>SHOUR</name><value><cyclestr>@H</cyclestr></value></envar>
+        <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+
+        <dependency>
+		<and>
+			<or>
+				<datadep><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS/@Y@m@d@H/gfs/gdas.t@Hz.atmanl.nemsio</cyclestr></datadep>
+				<datadep><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS/@Y@m@d@H/gfs/gdas.t@Hz.atmanl.nc</cyclestr></datadep>
+			</or>
+			<datadep><cyclestr offset="-24:00:00">/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem/gfs.@Y@m@d/@H/gfs.t@Hz.atmf000.nemsio</cyclestr></datadep>
+		</and> 
+        </dependency>
+</task>
+
+<task name="calcinc" cycledefs="gfs" maxtries="2">
+
+        <command>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/jobs/rocoto/calcinc.sh</command>
+
+        <jobname><cyclestr>rt_ccpp-chem_clacinc_@H</cyclestr></jobname>
+        <account>gsd-fv3</account>
+        <queue>batch</queue>
+        <nodes>1:ppn=2</nodes>
+        <walltime>00:30:00</walltime>
+        <native>--export=NONE</native>
+        <join><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem/logs/@Y@m@d@H/calcinc.log</cyclestr></join>
+
+        <envar><name>RUN_ENVIR</name><value>emc</value></envar>
+        <envar><name>HOMEgfs</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem</value></envar>
+        <envar><name>OUTDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem</value></envar>
+        <envar><name>ICSDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS</value></envar>
+        <envar><name>EXPDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp-chem</value></envar>
+        <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+        <envar><name>CDUMP</name><value>gfs</value></envar>
+        <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+        <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+        <dependency>
+	        <and>
+			<or>
+                      		<datadep><cyclestr>/scratch1/BMC/gsd-fv3/NCEPDEV/stmp3/rtfim/RUNDIRS/rt_ccpp-chem/@Y@m@d@H/gfs/regrid/atmanl.@Y@m@d@H</cyclestr></datadep>
+                      		<datadep><cyclestr>/scratch1/BMC/gsd-fv3/NCEPDEV/stmp3/rtfim/RUNDIRS/rt_ccpp-chem/@Y@m@d@H/gfs/regrid/atmanl.@Y@m@d@H.nc</cyclestr></datadep>
+			</or>
+			<datadep><cyclestr offset="-24:00:00">/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem/gfs.@Y@m@d/@H/gfs.t@Hz.atmf024.nemsio</cyclestr></datadep>  
+			<taskdep task="regrid"/>
+                </and> 
+        </dependency>
+</task>
+
+<task name="prepchem" cycledefs="gfs" maxtries="2">
+
+        <command>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/jobs/rocoto/prepchem.sh</command>
+
+        <jobname><cyclestr>rt_ccpp-chem_prepchem_@H</cyclestr></jobname>
+        <account>gsd-fv3</account>
+        <queue>batch</queue>
+        <nodes>1:ppn=2</nodes>
+        <walltime>00:15:00</walltime>
+        <native>--export=NONE</native>
+        <join><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem/logs/@Y@m@d@H/prepchem.log</cyclestr></join>
+
+	<envar><name>RUN_ENVIR</name><value>emc</value></envar>
+	<envar><name>HOMEgfs</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem</value></envar>
+	<envar><name>EXPDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp-chem</value></envar>
+	<envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+	<envar><name>CDUMP</name><value>gfs</value></envar>
+	<envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+	<envar><name>SYEAR</name><value><cyclestr>@Y</cyclestr></value></envar>
+	<envar><name>SMONTH</name><value><cyclestr>@m</cyclestr></value></envar>
+	<envar><name>SDAY</name><value><cyclestr>@d</cyclestr></value></envar>
+	<envar><name>SHOUR</name><value><cyclestr>@H</cyclestr></value></envar>
+	<envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+        <dependency>
+              	<or>
+                  <datadep><cyclestr>/scratch2/BMC/public/data/grids/sdsu/emissions/@Y@m@d/meanFRP.@Y@m@d.FV3.C384Grid.tile6.bin</cyclestr></datadep>	
+                  <datadep><cyclestr>/scratch2/BMC/gsd-fv3-dev/Judy.K.Henderson/sdsu_emissions/meanFRP.@Y@m@d.FV3.C384Grid.tile6.bin</cyclestr></datadep>
+                  <!--<datadep><cyclestr>&EMIDIR;/meanFRP.@Y@m@d.FV3.C384Grid.tile6.bin</cyclestr></datadep>	 -->
+              	</or>
+	</dependency>
+</task>
+
+<task name="gfsfcst" cycledefs="gfs" maxtries="2">
+
+	<command>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/jobs/rocoto/fcst.sh</command>
+
+	<jobname><cyclestr>rt_ccpp-chem_gfsfcst_@H</cyclestr></jobname>
+	<account>gsd-fv3</account>
+	<queue>batch</queue>
+	<nodes>8:ppn=40:tpp=1</nodes>
+	<walltime>08:00:00</walltime>
+	
+	<native>--export=NONE</native>
+
+	<join><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem/logs/@Y@m@d@H/gfsfcst.log</cyclestr></join>
+
+	<envar><name>RUN_ENVIR</name><value>emc</value></envar>
+	<envar><name>HOMEgfs</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem</value></envar>
+	<envar><name>EXPDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp-chem</value></envar>
+	<envar><name>ROTDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem</value></envar>
+	<envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+	<envar><name>CDUMP</name><value>gfs</value></envar>
+	<envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+	<envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+
+	<dependency>
+		<and>
+                       <taskdep task="prepchem"/>
+                       <taskdep task="calcinc"/> 
+                       <datadep><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS/@Y@m@d@H/gfs/C384/INPUT/sfc_data.tile6.nc</cyclestr></datadep>
+                       <datadep><cyclestr>/scratch1/BMC/gsd-fv3/NCEPDEV/stmp3/rtfim/RUNDIRS/rt_ccpp-chem/@Y@m@d@H/gfs/calcinc/atminc.nc</cyclestr></datadep>
+	               <datadep><cyclestr offset="-24:00:00">/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem/gfs.@Y@m@d/@H/</cyclestr><cyclestr>RESTART/@Y@m@d.000000.fv_tracer.res.tile1.nc</cyclestr></datadep>  
+	               <datadep><cyclestr offset="-24:00:00">/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem/gfs.@Y@m@d/@H/</cyclestr><cyclestr offset="00:00:00">RESTART/@Y@m@d.000000.coupler.res</cyclestr></datadep>	
+               </and>
+        </dependency>
+</task> 
+
+<metatask name="gfspost">
+
+	<var name="grp">001 002 003 004 005 006 007 008 009 010 011 012 013 014 015 016 017 018 019 020 021 022 023 024 025 026 027 028 029</var>
+	<var name="dep">f000 f006 f012 f018 f024 f030 f036 f042 f048 f054 f060 f066 f072 f078 f084 f090 f096 f102 f108 f114 f120 f126 f132 f138 f144 f150 f156 f162 f168</var>
+	<var name="lst">f000 f006 f012 f018 f024 f030 f036 f042 f048 f054 f060 f066 f072 f078 f084 f090 f096 f102 f108 f114 f120 f126 f132 f138 f144 f150 f156 f162 f168</var>
+
+	<task name="gfspost#grp#" cycledefs="gfs" maxtries="2">
+
+		<command>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/jobs/rocoto/post.sh</command>
+
+		<jobname><cyclestr>rt_ccpp-chem_gfspost#grp#_@H</cyclestr></jobname>
+		<account>gsd-fv3</account>
+		<queue>batch</queue>
+		<nodes>4:ppn=12:tpp=1</nodes>
+		<walltime>00:30:00</walltime>
+		
+		<native>--export=NONE</native>
+
+		<join><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem/logs/@Y@m@d@H/gfspost#grp#.log</cyclestr></join>
+
+		<envar><name>RUN_ENVIR</name><value>emc</value></envar>
+		<envar><name>HOMEgfs</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem</value></envar>
+		<envar><name>EXPDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp-chem</value></envar>
+		<envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+		<envar><name>CDUMP</name><value>gfs</value></envar>
+		<envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+		<envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+		<envar><name>FHRGRP</name><value>#grp#</value></envar>
+		<envar><name>FHRLST</name><value>#lst#</value></envar>
+		<envar><name>ROTDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem</value></envar>
+
+		<dependency>
+			<datadep><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem/gfs.@Y@m@d/@H/gfs.t@Hz.log#dep#.txt</cyclestr></datadep>
+		</dependency>
+
+	</task>
+
+</metatask>
+
+<task name="gfsarch" cycledefs="gfs" maxtries="2" final="true">
+
+	<command>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/jobs/rocoto/arch_gsd.sh</command>
+
+	<jobname><cyclestr>rt_ccpp-chem_gfsarch_@H</cyclestr></jobname>
+	<account>gsd-fv3</account>
+	<queue>batch</queue>
+	<nodes>1:ppn=1:tpp=1</nodes>
+	<walltime>06:00:00</walltime>
+	<memory>2048M</memory>
+	<native>--export=NONE</native>
+
+	<join><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem/logs/@Y@m@d@H/gfsarch.log</cyclestr></join>
+
+	<envar><name>RUN_ENVIR</name><value>emc</value></envar>
+	<envar><name>HOMEgfs</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem</value></envar>
+	<envar><name>EXPDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp-chem</value></envar>
+	<envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+	<envar><name>CDUMP</name><value>gfs</value></envar>
+	<envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+	<envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+
+	<dependency>
+		<and>
+			<metataskdep metatask="gfspost"/>
+			<streq><left>YES</left><right>YES</right></streq>
+                        <datadep age="600"><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem/gfs.@Y@m@d/@H/ncl/a2/files.zip</cyclestr></datadep>
+		</and>
+	</dependency>
+
+</task>
+
+
+</workflow>

--- a/FV3GFSwfm/rt_ccpp-chem/noent_rtchem.xml
+++ b/FV3GFSwfm/rt_ccpp-chem/noent_rtchem.xml
@@ -1,0 +1,242 @@
+<?xml version="1.0"?>
+<!DOCTYPE workflow [
+<!--
+	PROGRAM
+		Main workflow manager for Forecast only Global Forecast System
+
+	AUTHOR:
+		Rahul Mahajan
+		rahul.mahajan@noaa.gov
+
+	NOTES:
+		This workflow was automatically generated at 2021-04-11 13:25:05.897628
+	--><!-- Experiment parameters such as name, cycle, resolution --><!ENTITY PSLOT "rt_ccpp-chem">
+<!ENTITY CDUMP "gfs">
+<!ENTITY CASE "C384">
+<!-- Experiment parameters such as starting, ending dates --><!ENTITY SDATE "202103230000">
+<!ENTITY EDATE "203001100000">
+<!ENTITY INTERVAL "24:00:00">
+<!-- Run Envrionment --><!ENTITY RUN_ENVIR "emc">
+<!-- Experiment related directories --><!ENTITY EXPDIR "/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp-chem">
+<!ENTITY ROTDIR "/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem">
+<!ENTITY ICSDIR "/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS">
+<!-- use RUNDIR1 as long as FV3-CHEM is still running in realtime   --><!ENTITY RUNDIR1 "/scratch1/BMC/gsd-fv3/NCEPDEV/stmp3/rtfim/RUNDIRS/rt_fv3gfs_chem">
+<!ENTITY RUNDIR "/scratch1/BMC/gsd-fv3/NCEPDEV/stmp3/rtfim/RUNDIRS/rt_ccpp-chem">
+<!-- use lzhang GBBEPx directory as long as FV3-CHEM is still running in realtime 
+        <!ENTITY EMIDIR "/scratch2/BMC/public/data/grids/sdsu/emissions"> --><!ENTITY EMIDIR "/scratch1/BMC/gsd-fv3-dev/lzhang/GBBEPx">
+<!ENTITY ARCEMI "/scratch2/BMC/gsd-fv3-dev/Judy.K.Henderson/sdsu_emissions">
+<!-- Directories for driving the workflow --><!ENTITY HOMEgfs "/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem">
+<!ENTITY JOBS_DIR "/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/jobs/rocoto">
+<!-- Machine related entities --><!ENTITY ACCOUNT "gsd-fv3">
+<!ENTITY QUEUE "batch">
+<!ENTITY QUEUE_ARCH "service">
+<!ENTITY SCHEDULER "slurm">
+<!-- Toggle HPSS archiving --><!ENTITY ARCHIVE_TO_HPSS "YES">
+<!-- ROCOTO parameters that control workflow --><!ENTITY CYCLETHROTTLE "2">
+<!ENTITY TASKTHROTTLE "25">
+<!ENTITY MAXTRIES "2">
+<!-- BEGIN: Resource requirements for the workflow --><!ENTITY QUEUE_CALCINC "&QUEUE;">
+<!ENTITY WALLTIME_CALCINC "00:30:00">
+<!ENTITY RESOURCES_CALCINC "<nodes>1:ppn=2</nodes>">
+<!ENTITY MEMORY_CALCINC "">
+<!ENTITY NATIVE_CALCINC "--export=NONE">
+<!ENTITY QUEUE_PREP_CHEM_SRC "&QUEUE;">
+<!ENTITY WALLTIME_PREP_CHEM_SRC "00:15:00">
+<!ENTITY RESOURCES_PREP_CHEM_SRC "<nodes>1:ppn=2</nodes>">
+<!ENTITY MEMORY_PREP_CHEM_SRC "">
+<!ENTITY NATIVE_PREP_CHEM_SRC "--export=NONE">
+<!ENTITY QUEUE_FCST_GFS "&QUEUE;">
+<!ENTITY WALLTIME_FCST_GFS "08:00:00">
+<!ENTITY RESOURCES_FCST_GFS "<nodes>8:ppn=40:tpp=1</nodes>">
+<!ENTITY NATIVE_FCST_GFS "--export=NONE">
+<!ENTITY QUEUE_POST_GFS "&QUEUE;">
+<!ENTITY WALLTIME_POST_GFS "00:30:00">
+<!ENTITY RESOURCES_POST_GFS "<nodes>4:ppn=12:tpp=1</nodes>">
+<!ENTITY NATIVE_POST_GFS "--export=NONE">
+<!ENTITY QUEUE_ARCH_GFS "&QUEUE;">
+<!ENTITY WALLTIME_ARCH_GFS "06:00:00">
+<!ENTITY RESOURCES_ARCH_GFS "<nodes>1:ppn=1:tpp=1</nodes>">
+<!ENTITY MEMORY_ARCH_GFS "2048M">
+<!ENTITY NATIVE_ARCH_GFS "--export=NONE">
+<!-- END: Resource requirements for the workflow -->]>
+<workflow realtime="T" scheduler="slurm" cyclethrottle="2" taskthrottle="25">
+
+	<log verbosity="10"><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp-chem/logs/@Y@m@d@H.log</cyclestr></log>
+
+	<!-- Define the cycles -->
+	<cycledef group="gfs">202103230000 203001100000 24:00:00</cycledef>
+
+<task name="calcinc" cycledefs="gfs" maxtries="2">
+
+        <command>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/jobs/rocoto/calcinc.sh</command>
+
+        <jobname><cyclestr>rt_ccpp-chem_clacinc_@H</cyclestr></jobname>
+        <account>gsd-fv3</account>
+        <queue>batch</queue>
+        <nodes>1:ppn=2</nodes>
+        <walltime>00:30:00</walltime>
+        <native>--export=NONE</native>
+        <join><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem/logs/@Y@m@d@H/calcinc.log</cyclestr></join>
+
+        <envar><name>RUN_ENVIR</name><value>emc</value></envar>
+        <envar><name>HOMEgfs</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem</value></envar>
+        <envar><name>OUTDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem</value></envar>
+        <envar><name>ICSDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS</value></envar>
+        <envar><name>EXPDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp-chem</value></envar>
+        <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+        <envar><name>CDUMP</name><value>gfs</value></envar>
+        <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+        <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+        <dependency>
+	        <and>
+			<or>
+                      		<!--<datadep><cyclestr>&RUNDIR;/@Y@m@d@H/&CDUMP;/regrid/atmanl.@Y@m@d@H</cyclestr></datadep> -->
+                      		<!--<datadep><cyclestr>&RUNDIR;/@Y@m@d@H/&CDUMP;/regrid/atmanl.@Y@m@d@H.nc</cyclestr></datadep> -->
+                      		<datadep><cyclestr>/scratch1/BMC/gsd-fv3/NCEPDEV/stmp3/rtfim/RUNDIRS/rt_fv3gfs_chem/@Y@m@d@H/gfs/regrid/atmanl.@Y@m@d@H</cyclestr></datadep>
+                      		<datadep><cyclestr>/scratch1/BMC/gsd-fv3/NCEPDEV/stmp3/rtfim/RUNDIRS/rt_fv3gfs_chem/@Y@m@d@H/gfs/regrid/atmanl.@Y@m@d@H.nc</cyclestr></datadep>
+			</or>
+	              <datadep><cyclestr offset="-24:00:00">/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem/gfs.@Y@m@d/@H/gfs.t@Hz.atmf024.nemsio</cyclestr></datadep>  
+                </and> 
+        </dependency>
+</task>
+
+<task name="prepchem" cycledefs="gfs" maxtries="2">
+
+        <command>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/jobs/rocoto/prepchem.sh</command>
+
+        <jobname><cyclestr>rt_ccpp-chem_prepchem_@H</cyclestr></jobname>
+        <account>gsd-fv3</account>
+        <queue>batch</queue>
+        <nodes>1:ppn=2</nodes>
+        <walltime>00:15:00</walltime>
+        <native>--export=NONE</native>
+        <join><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem/logs/@Y@m@d@H/prepchem.log</cyclestr></join>
+
+	<envar><name>RUN_ENVIR</name><value>emc</value></envar>
+	<envar><name>HOMEgfs</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem</value></envar>
+	<envar><name>EXPDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp-chem</value></envar>
+	<envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+	<envar><name>CDUMP</name><value>gfs</value></envar>
+	<envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+	<envar><name>SYEAR</name><value><cyclestr>@Y</cyclestr></value></envar>
+	<envar><name>SMONTH</name><value><cyclestr>@m</cyclestr></value></envar>
+	<envar><name>SDAY</name><value><cyclestr>@d</cyclestr></value></envar>
+	<envar><name>SHOUR</name><value><cyclestr>@H</cyclestr></value></envar>
+	<envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+        <dependency>
+              	<or>
+                  <datadep><cyclestr>/scratch1/BMC/gsd-fv3-dev/lzhang/GBBEPx/@Y@m@d/meanFRP.@Y@m@d.FV3.C384Grid.tile6.bin</cyclestr></datadep>	
+                  <datadep><cyclestr>/scratch2/BMC/gsd-fv3-dev/Judy.K.Henderson/sdsu_emissions/meanFRP.@Y@m@d.FV3.C384Grid.tile6.bin</cyclestr></datadep>
+                  <!--<datadep><cyclestr>&EMIDIR;/meanFRP.@Y@m@d.FV3.C384Grid.tile6.bin</cyclestr></datadep>	 -->
+              	</or>
+	</dependency>
+</task>
+
+<task name="gfsfcst" cycledefs="gfs" maxtries="2">
+
+	<command>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/jobs/rocoto/fcst.sh</command>
+
+	<jobname><cyclestr>rt_ccpp-chem_gfsfcst_@H</cyclestr></jobname>
+	<account>gsd-fv3</account>
+	<queue>batch</queue>
+	<nodes>8:ppn=40:tpp=1</nodes>
+	<walltime>08:00:00</walltime>
+	
+	<native>--export=NONE</native>
+
+	<join><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem/logs/@Y@m@d@H/gfsfcst.log</cyclestr></join>
+
+	<envar><name>RUN_ENVIR</name><value>emc</value></envar>
+	<envar><name>HOMEgfs</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem</value></envar>
+	<envar><name>EXPDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp-chem</value></envar>
+	<envar><name>ROTDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem</value></envar>
+	<envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+	<envar><name>CDUMP</name><value>gfs</value></envar>
+	<envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+	<envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+
+	<dependency>
+		<and>
+                       <taskdep task="prepchem"/>
+                       <taskdep task="calcinc"/> 
+                       <datadep><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS/@Y@m@d@H/gfs/C384/INPUT/sfc_data.tile6.nc</cyclestr></datadep>
+                       <datadep><cyclestr>/scratch1/BMC/gsd-fv3/NCEPDEV/stmp3/rtfim/RUNDIRS/rt_ccpp-chem/@Y@m@d@H/gfs/calcinc/atminc.nc</cyclestr></datadep>
+	               <datadep><cyclestr offset="-24:00:00">/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem/gfs.@Y@m@d/@H/</cyclestr><cyclestr>RESTART/@Y@m@d.000000.fv_tracer.res.tile1.nc</cyclestr></datadep>  
+	               <datadep><cyclestr offset="-24:00:00">/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem/gfs.@Y@m@d/@H/</cyclestr><cyclestr offset="00:00:00">RESTART/@Y@m@d.000000.coupler.res</cyclestr></datadep>	
+               </and>
+        </dependency>
+</task> 
+
+<metatask name="gfspost">
+
+	<var name="grp">001 002 003 004 005 006 007 008 009 010 011 012 013 014 015 016 017 018 019 020 021 022 023 024 025 026 027 028 029</var>
+	<var name="dep">f000 f006 f012 f018 f024 f030 f036 f042 f048 f054 f060 f066 f072 f078 f084 f090 f096 f102 f108 f114 f120 f126 f132 f138 f144 f150 f156 f162 f168</var>
+	<var name="lst">f000 f006 f012 f018 f024 f030 f036 f042 f048 f054 f060 f066 f072 f078 f084 f090 f096 f102 f108 f114 f120 f126 f132 f138 f144 f150 f156 f162 f168</var>
+
+	<task name="gfspost#grp#" cycledefs="gfs" maxtries="2">
+
+		<command>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/jobs/rocoto/post.sh</command>
+
+		<jobname><cyclestr>rt_ccpp-chem_gfspost#grp#_@H</cyclestr></jobname>
+		<account>gsd-fv3</account>
+		<queue>batch</queue>
+		<nodes>4:ppn=12:tpp=1</nodes>
+		<walltime>00:30:00</walltime>
+		
+		<native>--export=NONE</native>
+
+		<join><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem/logs/@Y@m@d@H/gfspost#grp#.log</cyclestr></join>
+
+		<envar><name>RUN_ENVIR</name><value>emc</value></envar>
+		<envar><name>HOMEgfs</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem</value></envar>
+		<envar><name>EXPDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp-chem</value></envar>
+		<envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+		<envar><name>CDUMP</name><value>gfs</value></envar>
+		<envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+		<envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+		<envar><name>FHRGRP</name><value>#grp#</value></envar>
+		<envar><name>FHRLST</name><value>#lst#</value></envar>
+		<envar><name>ROTDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem</value></envar>
+
+		<dependency>
+			<datadep><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem/gfs.@Y@m@d/@H/gfs.t@Hz.log#dep#.txt</cyclestr></datadep>
+		</dependency>
+
+	</task>
+
+</metatask>
+
+<task name="gfsarch" cycledefs="gfs" maxtries="2" final="true">
+
+	<command>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/jobs/rocoto/arch_gsd.sh</command>
+
+	<jobname><cyclestr>rt_ccpp-chem_gfsarch_@H</cyclestr></jobname>
+	<account>gsd-fv3</account>
+	<queue>batch</queue>
+	<nodes>1:ppn=1:tpp=1</nodes>
+	<walltime>06:00:00</walltime>
+	<memory>2048M</memory>
+	<native>--export=NONE</native>
+
+	<join><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem/logs/@Y@m@d@H/gfsarch.log</cyclestr></join>
+
+	<envar><name>RUN_ENVIR</name><value>emc</value></envar>
+	<envar><name>HOMEgfs</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem</value></envar>
+	<envar><name>EXPDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp-chem</value></envar>
+	<envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+	<envar><name>CDUMP</name><value>gfs</value></envar>
+	<envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+	<envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+
+	<dependency>
+		<and>
+			<metataskdep metatask="gfspost"/>
+			<streq><left>YES</left><right>YES</right></streq>
+                        <datadep age="600"><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp-chem/gfs.@Y@m@d/@H/ncl/a2/files.zip</cyclestr></datadep>
+		</and>
+	</dependency>
+
+</task>
+
+
+</workflow>

--- a/FV3GFSwfm/rt_ccpp_c384/config.anal
+++ b/FV3GFSwfm/rt_ccpp_c384/config.anal
@@ -1,0 +1,126 @@
+#!/bin/ksh -x
+
+########## config.anal ##########
+# Analysis specific
+
+echo "BEGIN: config.anal"
+
+# Get task specific resources
+. $EXPDIR/config.resources anal
+
+if [ $DONST = "YES" ]; then
+    . $EXPDIR/config.nsst
+fi
+
+if [[ "$CDUMP" = "gfs" ]] ; then
+    export USE_RADSTAT="NO" # This can be only used when bias correction is not-zero.
+    export GENDIAG="NO"
+    export SETUP='diag_rad=.false.,diag_pcp=.false.,diag_conv=.false.,diag_ozone=.false.,write_diag(3)=.false.,niter(2)=100,'
+    export DIAG_TARBALL="NO"
+fi
+
+export ANALYSISSH="$HOMEgsi/scripts/exglobal_analysis_fv3gfs.sh.ecf"
+export npe_gsi=$npe_anal
+
+# Set parameters specific to L127
+if [ $LEVS = "128" ]; then
+    export GRIDOPTS="nlayers(63)=1,nlayers(64)=1,"
+    export SETUP="gpstop=55,nsig_ext=56,$SETUP"
+fi
+
+# Set namelist option for LETKF
+export lobsdiag_forenkf=".false."  # anal does not need to write out jacobians
+                                   # set to .true. in config.eobs and config.eupd
+
+if [ $OUTPUT_FILE = "nemsio" ]; then
+    export DO_CALC_INCREMENT="YES"
+    export DO_CALC_ANALYSIS="NO"
+fi
+
+# Do not process the following datasets
+export GSNDBF=${GSNDBF:-/dev/null}
+export AMSREBF=${AMSREBF:-/dev/null}
+export SSMITBF=${SSMITBF:-/dev/null}
+export AMSR2BF=${AMSR2BF:-/dev/null}
+
+
+# Use experimental dumps in GFS v16 parallels
+export ABIBF="/dev/null"
+if [[ "$CDATE" -ge "2019022800" ]] ; then
+    export ABIBF="$DMPDIR/${CDUMP}x.${PDY}/${cyc}/${CDUMP}.t${cyc}z.gsrcsr.tm00.bufr_d"
+    if [[ "$CDATE" -ge "2019111000" && "$CDATE" -le "2020052612" ]]; then
+	export ABIBF="$DMPDIR/${CDUMP}y.${PDY}/${cyc}/${CDUMP}.t${cyc}z.gsrcsr.tm00.bufr_d"
+    fi
+fi
+
+export AHIBF="/dev/null"
+if [[ "$CDATE" -ge "2019042300" ]]; then
+    export AHIBF="$DMPDIR/${CDUMP}x.${PDY}/${cyc}/${CDUMP}.t${cyc}z.ahicsr.tm00.bufr_d"
+fi
+
+
+# Adjust data usage for GFS v16 parallels
+#
+#   NOTE:  Remember to set PRVT in config.prep as OBERROR is set below
+#
+# Set default values
+export CONVINFO=$FIXgsi/global_convinfo.txt
+export OZINFO=$FIXgsi/global_ozinfo.txt
+export SATINFO=$FIXgsi/global_satinfo.txt
+export OBERROR=$FIXgsi/prepobs_errtable.global
+
+
+# Set convinfo and prepobs.errtable.global for start of GFS v16 parallels
+if [[ "$CDATE" -ge "2019021900" && "$CDATE" -lt "2019110706" ]]; then
+    export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2019021900
+    export OBERROR=$FIXgsi/gfsv16_historical/prepobs_errtable.global.2019021900
+fi
+
+# Place GOES-15 AMVs in monitor, assimilate GOES-17 AMVs, assimilate KOMPSAT-5 gps
+if [[ "$CDATE" -ge "2019110706" && "$CDATE" -lt "2020040718" ]]; then
+    export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2019110706
+    export OBERROR=$FIXgsi/gfsv16_historical/prepobs_errtable.global.2019110706
+fi
+
+# Assimilate 135 (T) & 235 (uv) Canadian AMDAR observations
+if [[ "$CDATE" -ge "2020040718" && "$CDATE" -lt "2020052612" ]]; then
+    export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2020040718
+fi
+
+# NOTE:
+#   As of 2020052612, gfsv16_historical/global_convinfo.txt.2020052612 is
+#   identical to ../global_convinfo.txt.  Thus, the logic below is not
+#   needed at this time.
+# Assimilate COSMIC-2 GPS
+##if [[ "$CDATE" -ge "2020052612" && "$CDATE" -lt "YYYYMMDDHH" ]]; then
+##    export CONVINFO=$FIXgsi/gfsv16_historical/global_convinfo.txt.2020052612
+##fi
+
+
+# Turn off assmilation of OMPS during period of bad data
+if [[ "$CDATE" -ge "2020011600" && "$CDATE" -lt "2020011806" ]]; then
+    export OZINFO=$FIXgsi/gfsv16_historical/global_ozinfo.txt.2020011600
+fi
+
+
+# Set satinfo for start of GFS v16 parallels
+if [[ "$CDATE" -ge "2019021900" && "$CDATE" -lt "2019110706" ]]; then
+    export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2019021900
+fi
+
+# Turn on assimilation of Metop-C AMSUA and MHS
+if [[ "$CDATE" -ge "2019110706" && "$CDATE" -lt "2020022012" ]]; then
+    export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2019110706
+fi
+
+# NOTE:  
+#   As of 2020022012, gfsv16_historical/global_satinfo.txt.2020022012 is
+#   identical to ../global_satinfo.txt.  Thus, the logic below is not
+#   needed at this time
+#
+# Turn off assmilation of all Metop-A MHS
+##  if [[ "$CDATE" -ge "2020022012" && "$CDATE" -lt "YYYYMMDDHH" ]]; then
+##      export SATINFO=$FIXgsi/gfsv16_historical/global_satinfo.txt.2020022012
+##  fi
+
+echo "END: config.anal"

--- a/FV3GFSwfm/rt_ccpp_c384/config.analcalc
+++ b/FV3GFSwfm/rt_ccpp_c384/config.analcalc
@@ -1,0 +1,13 @@
+#!/bin/ksh -x
+
+########## config.analcalc ##########
+# GFS post-anal specific (non-diag)
+
+echo "BEGIN: config.analcalc"
+
+# Get task specific resources
+. $EXPDIR/config.resources analcalc
+
+export ANALCALCSH=$HOMEgsi/scripts/exglobal_analcalc_fv3gfs.sh.ecf
+
+echo "END: config.analcalc"

--- a/FV3GFSwfm/rt_ccpp_c384/config.analdiag
+++ b/FV3GFSwfm/rt_ccpp_c384/config.analdiag
@@ -1,0 +1,13 @@
+#!/bin/ksh -x
+
+########## config.analdiag ##########
+# GFS post-anal specific (diag)
+
+echo "BEGIN: config.analdiag"
+
+# Get task specific resources
+. $EXPDIR/config.resources analdiag
+
+export ANALDIAGSH=$HOMEgsi/scripts/exglobal_analdiag_fv3gfs.sh.ecf
+
+echo "END: config.analdiag"

--- a/FV3GFSwfm/rt_ccpp_c384/config.arch
+++ b/FV3GFSwfm/rt_ccpp_c384/config.arch
@@ -1,0 +1,25 @@
+#!/bin/ksh -x
+
+########## config.arch ##########
+# Archive specific
+
+echo "BEGIN: config.arch"
+
+# Get task specific resources
+. $EXPDIR/config.resources arch
+
+#--online archive of nemsio files for fit2obs verification
+export FITSARC="YES"
+export FHMAX_FITS=132
+[[ "$FHMAX_FITS" -gt "$FHMAX_GFS" ]] && export FHMAX_FITS=$FHMAX_GFS
+
+#--starting and ending hours of previous cycles to be removed from rotating directory
+export RMOLDSTD=144
+export RMOLDEND=24
+
+#--keep forcing data for running gldas step
+if [[ "$DO_GLDAS" == "YES" && "$CDUMP" == "gdas" ]]; then
+     [[ $RMOLDSTD -lt 144 ]] && export RMOLDSTD=144   
+fi
+
+echo "END: config.arch"

--- a/FV3GFSwfm/rt_ccpp_c384/config.awips
+++ b/FV3GFSwfm/rt_ccpp_c384/config.awips
@@ -1,0 +1,17 @@
+#!/bin/ksh -x
+
+########## config.awips ##########
+# GFS awips step specific
+
+echo "BEGIN: config.awips"
+
+# Get task specific resources
+. $EXPDIR/config.resources awips
+
+export AWIPS20SH=$HOMEgfs/jobs/JGFS_AWIPS_20KM_1P0DEG
+export AWIPSG2SH=$HOMEgfs/jobs/JGFS_AWIPS_G2
+
+# No. of concurrent awips jobs
+export NAWIPSGRP=42
+
+echo "END: config.awips"

--- a/FV3GFSwfm/rt_ccpp_c384/config.base
+++ b/FV3GFSwfm/rt_ccpp_c384/config.base
@@ -1,0 +1,296 @@
+#!/bin/ksh -x
+
+########## config.base ##########
+# Common to all steps
+
+echo "BEGIN: config.base"
+
+# Machine environment
+export machine="HERA"
+
+# EMC parallel or NCO production
+export RUN_ENVIR="emc"
+
+# Account, queue, etc.
+export ACCOUNT="gsd-fv3"
+export QUEUE="batch"
+export QUEUE_ARCH="service"
+
+# Project to use in mass store:
+HPSS_PROJECT=fim
+
+# Directories relative to installation areas:
+export HOMEgfs=/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem
+export PARMgfs=$HOMEgfs/parm
+export FIXgfs=$HOMEgfs/fix
+export USHgfs=$HOMEgfs/ush
+export UTILgfs=$HOMEgfs/util
+export EXECgfs=$HOMEgfs/exec
+export SCRgfs=$HOMEgfs/scripts
+
+########################################################################
+
+# GLOBAL static environment parameters
+export NWPROD="/scratch1/NCEPDEV/global/glopara/nwpara"
+export DMPDIR="/scratch1/NCEPDEV/global/glopara/dump"
+export RTMFIX=$CRTM_FIX
+
+# USER specific paths
+export HOMEDIR="/scratch1/NCEPDEV/global/$USER"
+export STMP="/scratch1/BMC/gsd-fv3/NCEPDEV/stmp3/$USER"
+export PTMP="/scratch1/BMC/gsd-fv3/NCEPDEV/stmp4/$USER"
+export NOSCRUB="$HOMEDIR"
+
+# Base directories for various builds
+export BASE_GIT="/scratch1/NCEPDEV/global/glopara/git"
+export BASE_SVN="/scratch1/NCEPDEV/global/glopara/svn"
+
+#### CCPP Suite
+#### export CCPP_SUITE="FV3_GSD_v0"        # GSDsuite 
+#### export CCPP_SUITE="FV3_GSD_noah"      # GSDsuite + NOAH LSM  
+#### export CCPP_SUITE="FV3_GFS_v16beta"   # EMC v16beta
+#### export CCPP_SUITE="FV3_GFS_v15_gsd_chem"            # EMC v15_gsd_chem , using newer ozone_2015
+export CCPP_SUITE="FV3_GFS_v15"            # EMC v15, using newer ozone_2015
+#export CCPP_SUITE="FV3_GFS_2017_gfdlmp_gsd_chem"            # GSL:FV3_GFS_2017_gfdlmp_gsd_chem
+
+# Toggle to turn on/off GFS downstream processing.
+export DO_BUFRSND="YES"
+export DO_GEMPAK="NO"
+export DO_AWIPS="NO"
+
+# NO for retrospective parallel; YES for real-time parallel
+#  arch.sh uses REALTIME for MOS.  Need to set REALTIME=YES
+#  if want MOS written to HPSS.   Should update arch.sh to
+#  use RUNMOS flag (currently in config.vrfy)
+export REALTIME="YES"
+
+
+####################################################
+# DO NOT ADD MACHINE DEPENDENT STUFF BELOW THIS LINE
+# IF YOU HAVE TO MAKE MACHINE SPECIFIC CHANGES BELOW
+# FEEL FREE TO MOVE THEM ABOVE THIS LINE TO KEEP IT
+# CLEAR
+####################################################
+# Build paths relative to $HOMEgfs
+export HOMEgsi="$HOMEgfs"
+export FIXgsi="$HOMEgfs/fix/fix_gsi"
+export HOMEfv3gfs="$HOMEgfs/sorc/fv3gfs.fd"
+export HOMEpost="$HOMEgfs"
+export HOMEobsproc_prep="$BASE_GIT/obsproc/gfsv16b/obsproc_prep.iss70457.netcdfhistory"
+export HOMEobsproc_network="$BASE_GIT/obsproc/gfsv16b/obsproc_global.iss71402.supportGFSv16"
+export HOMEobsproc_global=$HOMEobsproc_network
+export BASE_VERIF="$BASE_SVN/verif/global/tags/vsdb"
+
+# CONVENIENT utility scripts and other environment parameters
+export NCP="/bin/cp -p"
+export NMV="/bin/mv"
+export NLN="/bin/ln -sf"
+export VERBOSE="YES"
+export KEEPDATA="YES"
+export CHGRP_CMD="chgrp rstprod"
+export NEMSIOGET="$HOMEgfs/exec/nemsio_get"
+export NCDUMP="$NETCDF/bin/ncdump"
+export NCLEN="$HOMEgfs/ush/getncdimlen"
+
+# Machine environment, jobs, and other utility scripts
+export BASE_ENV="$HOMEgfs/env"
+export BASE_JOB="$HOMEgfs/jobs/rocoto"
+
+# EXPERIMENT specific environment parameters
+export SDATE=2020120100
+export EDATE=2030011000
+export assim_freq=24                     ## JKH
+export PSLOT="rt_ccpp_c384"
+export EXPDIR="/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/$PSLOT"
+export ROTDIR="/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/$PSLOT"
+export ROTDIR_DUMP="YES"                #Note: A value of "NO" does not currently work
+export DUMP_SUFFIX=""
+if [[ "$CDATE" -ge "2019092100" && "$CDATE" -le "2019110700" ]]; then
+    export DUMP_SUFFIX="p"              # Use dumps from NCO GFS v15.3 parallel
+fi
+export RUNDIR="$STMP/RUNDIRS/$PSLOT"
+export RUNDIR1="/scratch1/BMC/gsd-fv3/NCEPDEV/stmp3/rtfim/RUNDIRS/rt_fv3gfs_chem"
+export DATAROOT="$RUNDIR/$CDATE/$CDUMP"
+export ARCDIR="$NOSCRUB/archive/$PSLOT"
+export ICSDIR="/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS"
+export ATARDIR="/BMC/$HPSS_PROJECT/2year/rt_CCPP-C384"
+
+# Commonly defined parameters in JJOBS
+export envir=${envir:-"prod"}
+export NET="gfs"
+export RUN=${RUN:-${CDUMP:-"gfs"}}
+export jlogfile="${EXPDIR}/logs/jlogfile"
+export ERRSCRIPT=${ERRSCRIPT:-'eval [[ $err = 0 ]]'}
+export LOGSCRIPT=${LOGSCRIPT:-""}
+#export ERRSCRIPT=${ERRSCRIPT:-"err_chk"}
+#export LOGSCRIPT=${LOGSCRIPT:-"startmsg"}
+export REDOUT="1>"
+export REDERR="2>"
+
+export SENDECF="NO"
+export SENDCOM="NO"
+export SENDDBN="NO"
+export SENDSDM="NO"
+
+# Include GSDChem coupling: off:0, on:1 !lzhang
+export GSDChem=1
+export EMITYPE=2 # 1: MODIS, 2: GBBEPx 
+
+
+# Resolution specific parameters
+export LEVS=65                                                 ## JKH
+export CASE="C384"
+export CASE_ENKF="@CASEENS@"
+
+# Surface cycle update frequency
+if [[ "$CDUMP" == "gdas" ]] ; then
+   export FHCYC=1
+   export FTSFS=10
+elif [[ "$CDUMP" == "gfs" ]] ; then
+   if [[ "$CCPP_SUITE" == "FV3_GSD_v0" ]] ; then
+       export FHCYC=0
+   else
+       export FHCYC=24
+   fi
+fi
+
+# Output frequency of the forecast model (for cycling)
+export FHMIN=0
+export FHMAX=9
+export FHOUT=3
+
+# Cycle to run EnKF  (set to BOTH for both gfs and gdas)
+export EUPD_CYC="gdas"
+
+# GFS cycle info
+export gfs_cyc=1 # 0: no GFS cycle, 1: 00Z only, 2: 00Z and 12Z only, 4: all 4 cycles.
+
+# GFS output and frequency
+export FHMIN_GFS=0
+
+export FHMAX_GFS_00=168                                      ## JKH
+export FHMAX_GFS_06=168                                      ## JKH
+export FHMAX_GFS_12=168                                      ## JKH
+export FHMAX_GFS_18=168                                      ## JKH
+export FHMAX_GFS=$(eval echo \${FHMAX_GFS_$cyc})
+
+export FHOUT_GFS=6                                           ## JKH
+export FHMAX_HF_GFS=0
+export FHOUT_HF_GFS=1
+export ILPOST=1           # gempak output frequency up to F120
+
+# GFS restart interval in hours
+export restart_interval_gfs=0
+
+
+# I/O QUILTING, true--use Write Component; false--use GFDL FMS
+# if quilting=true, choose OUTPUT_GRID as cubed_sphere_grid in netcdf or gaussian_grid
+# if gaussian_grid, set OUTPUT_FILE for nemsio or netcdf
+# WRITE_DOPOST=true, use inline POST
+export QUILTING=".true."
+export OUTPUT_GRID="gaussian_grid"
+export OUTPUT_FILE="nemsio"               ## JKH
+export WRITE_DOPOST=".false."
+
+# suffix options depending on file format
+if [ $OUTPUT_FILE = "netcdf" ]; then
+    export SUFFIX=".nc"
+    export NEMSIO_IN=".false."
+    export NETCDF_IN=".true."
+else
+    export SUFFIX=".nemsio"
+    export NEMSIO_IN=".true."
+    export NETCDF_IN=".false."
+fi
+
+# IAU related parameters
+export DOIAU="NO"        # Enable 4DIAU for control with 3 increments        ## JKH
+export IAUFHRS="3,6,9"
+export IAU_FHROT=`echo $IAUFHRS | cut -c1`
+export IAU_DELTHRS=6
+export IAU_OFFSET=6
+export DOIAU_ENKF="NO"   # Enable 4DIAU for EnKF ensemble                    ## JKH
+export IAUFHRS_ENKF="3,6,9"
+export IAU_DELTHRS_ENKF=6
+#if [[ "$SDATE" = "$CDATE" ]]; then
+if [[ "$SDATE" = "$CDATE" ]] || [[ "$DOIAU" = "NO" ]]; then
+  export IAU_OFFSET=0
+  export IAU_FHROT=0
+fi
+
+# Use Jacobians in eupd and thereby remove need to run eomg
+export lobsdiag_forenkf=".true."
+
+# run GLDAS to spin up land ICs
+export DO_GLDAS="NO"                                                       ## JKH
+export gldas_cyc=00
+
+# run wave component
+export DO_WAVE="NO"                                                        ## JKH
+export WAVE_CDUMP="both"
+
+# Microphysics Options: 99-ZhaoCarr, 8-Thompson; 6-WSM6, 10-MG, 11-GFDL
+if [[ "$CCPP_SUITE" == "FV3_GSD_v0" || "$CCPP_SUITE" == "FV3_GSD_noah" ]] ; then
+       export imp_physics=8
+else
+       export imp_physics=11
+fi
+
+# Shared parameters
+# Hybrid related
+export DOHYBVAR="YES"
+export NMEM_ENKF=@NMEM_ENKF@
+export SMOOTH_ENKF="NO"
+export l4densvar=".true."
+export lwrite4danl=".true."
+
+# EnKF output frequency
+if [ $DOHYBVAR = "YES" ]; then
+    export FHMIN_ENKF=3
+    export FHMAX_ENKF=9
+    if [ $l4densvar = ".true." ]; then
+        export FHOUT=1
+        export FHOUT_ENKF=1
+    else
+        export FHOUT_ENKF=3
+    fi
+fi
+
+# turned on nsst in anal and/or fcst steps, and turn off rtgsst
+export DONST="YES"
+if [ $DONST = "YES" ]; then export FNTSFA="        "; fi
+
+# The switch to apply SST elevation correction or not
+export nst_anl=.true.
+
+# Analysis increments to zero in CALCINCEXEC
+#export INCREMENTS_TO_ZERO="'liq_wat_inc','icmr_inc'"   #v16
+export INCREMENTS_TO_ZERO="'delz_inc','clwmr_inc','icmr_inc'"   #v15
+
+if [ $OUTPUT_FILE = "nemsio" ]; then
+    export DO_CALC_INCREMENT="YES"
+    export DO_CALC_ANALYSIS="NO"
+fi
+
+# Stratospheric increments to zero
+#export INCVARS_ZERO_STRAT="'sphum_inc','liq_wat_inc','icmr_inc'"
+#export INCVARS_EFOLD="5"
+
+# Swith to generate netcdf or binary diagnostic files.  If not specified,
+# script default to binary diagnostic files.   Set diagnostic file
+# variables here since used in both DA and vrfy jobs
+export netcdf_diag=".true."
+export binary_diag=".false."
+
+# Verification options
+export DO_METP="NO"                  # Run MET+ jobs          ## JKH
+
+# Archiving options
+export HPSSARCH="YES"        # save data to HPSS archive
+export ARCH_CYC=00           # Archive data at this cycle for warm_start capability
+export ARCH_WARMICFREQ=4     # Archive frequency in days for warm_start capability
+export ARCH_FCSTICFREQ=1     # Archive frequency in days for gdas and gfs forecast-only capability
+
+export DELETE_COM_IN_ARCHIVE_JOB="YES"   # NO=retain ROTDIR.  YES default in arch.sh and earc.sh.
+
+echo "END: config.base"

--- a/FV3GFSwfm/rt_ccpp_c384/config.base.default
+++ b/FV3GFSwfm/rt_ccpp_c384/config.base.default
@@ -1,0 +1,294 @@
+#!/bin/ksh -x
+
+########## config.base ##########
+# Common to all steps
+
+echo "BEGIN: config.base"
+
+# Machine environment
+export machine="@MACHINE@"
+
+# EMC parallel or NCO production
+export RUN_ENVIR="emc"
+
+# Account, queue, etc.
+export ACCOUNT="@ACCOUNT@"
+export QUEUE="@QUEUE@"
+export QUEUE_ARCH="@QUEUE_ARCH@"
+
+# Project to use in mass store:
+HPSS_PROJECT=fim
+
+# Directories relative to installation areas:
+export HOMEgfs=@HOMEgfs@
+export PARMgfs=$HOMEgfs/parm
+export FIXgfs=$HOMEgfs/fix
+export USHgfs=$HOMEgfs/ush
+export UTILgfs=$HOMEgfs/util
+export EXECgfs=$HOMEgfs/exec
+export SCRgfs=$HOMEgfs/scripts
+
+########################################################################
+
+# GLOBAL static environment parameters
+export NWPROD="@NWPROD@"
+export DMPDIR="@DMPDIR@"
+export RTMFIX=$CRTM_FIX
+
+# USER specific paths
+export HOMEDIR="@HOMEDIR@"
+export STMP="@STMP@"
+export PTMP="@PTMP@"
+export NOSCRUB="@NOSCRUB@"
+
+# Base directories for various builds
+export BASE_GIT="@BASE_GIT@"
+export BASE_SVN="@BASE_SVN@"
+
+#### CCPP Suite
+#### export CCPP_SUITE="FV3_GSD_v0"        # GSDsuite 
+#### export CCPP_SUITE="FV3_GSD_noah"      # GSDsuite + NOAH LSM  
+#### export CCPP_SUITE="FV3_GFS_v16beta"   # EMC v16beta
+export CCPP_SUITE="FV3_GFS_v15_gsd_chem"            # EMC v15_gsd_chem , using newer ozone_2015
+#export CCPP_SUITE="FV3_GFS_2017_gfdlmp_gsd_chem"            # GSL:FV3_GFS_2017_gfdlmp_gsd_chem
+
+# Toggle to turn on/off GFS downstream processing.
+export DO_BUFRSND="YES"
+export DO_GEMPAK="NO"
+export DO_AWIPS="NO"
+
+# NO for retrospective parallel; YES for real-time parallel
+#  arch.sh uses REALTIME for MOS.  Need to set REALTIME=YES
+#  if want MOS written to HPSS.   Should update arch.sh to
+#  use RUNMOS flag (currently in config.vrfy)
+export REALTIME="YES"
+
+
+####################################################
+# DO NOT ADD MACHINE DEPENDENT STUFF BELOW THIS LINE
+# IF YOU HAVE TO MAKE MACHINE SPECIFIC CHANGES BELOW
+# FEEL FREE TO MOVE THEM ABOVE THIS LINE TO KEEP IT
+# CLEAR
+####################################################
+# Build paths relative to $HOMEgfs
+export HOMEgsi="$HOMEgfs"
+export FIXgsi="$HOMEgfs/fix/fix_gsi"
+export HOMEfv3gfs="$HOMEgfs/sorc/fv3gfs.fd"
+export HOMEpost="$HOMEgfs"
+export HOMEobsproc_prep="$BASE_GIT/obsproc/gfsv16b/obsproc_prep.iss70457.netcdfhistory"
+export HOMEobsproc_network="$BASE_GIT/obsproc/gfsv16b/obsproc_global.iss71402.supportGFSv16"
+export HOMEobsproc_global=$HOMEobsproc_network
+export BASE_VERIF="$BASE_SVN/verif/global/tags/vsdb"
+
+# CONVENIENT utility scripts and other environment parameters
+export NCP="/bin/cp -p"
+export NMV="/bin/mv"
+export NLN="/bin/ln -sf"
+export VERBOSE="YES"
+export KEEPDATA="NO"
+export CHGRP_CMD="chgrp rstprod"
+export NEMSIOGET="$HOMEgfs/exec/nemsio_get"
+export NCDUMP="$NETCDF/bin/ncdump"
+export NCLEN="$HOMEgfs/ush/getncdimlen"
+
+# Machine environment, jobs, and other utility scripts
+export BASE_ENV="$HOMEgfs/env"
+export BASE_JOB="$HOMEgfs/jobs/rocoto"
+
+# EXPERIMENT specific environment parameters
+export SDATE=@SDATE@
+export EDATE=@EDATE@
+export assim_freq=24                     ## JKH
+export PSLOT="@PSLOT@"
+export EXPDIR="@EXPDIR@/$PSLOT"
+export ROTDIR="@ROTDIR@/$PSLOT"
+export ROTDIR_DUMP="YES"                #Note: A value of "NO" does not currently work
+export DUMP_SUFFIX=""
+if [[ "$CDATE" -ge "2019092100" && "$CDATE" -le "2019110700" ]]; then
+    export DUMP_SUFFIX="p"              # Use dumps from NCO GFS v15.3 parallel
+fi
+export RUNDIR="$STMP/RUNDIRS/$PSLOT"
+export DATAROOT="$RUNDIR/$CDATE/$CDUMP"
+export ARCDIR="$NOSCRUB/archive/$PSLOT"
+export ICSDIR="@ICSDIR@"
+export ATARDIR="/BMC/$HPSS_PROJECT/1year/gsd-ccpp-chem/$PSLOT"
+
+# Commonly defined parameters in JJOBS
+export envir=${envir:-"prod"}
+export NET="gfs"
+export RUN=${RUN:-${CDUMP:-"gfs"}}
+export jlogfile="${EXPDIR}/logs/jlogfile"
+export ERRSCRIPT=${ERRSCRIPT:-'eval [[ $err = 0 ]]'}
+export LOGSCRIPT=${LOGSCRIPT:-""}
+#export ERRSCRIPT=${ERRSCRIPT:-"err_chk"}
+#export LOGSCRIPT=${LOGSCRIPT:-"startmsg"}
+export REDOUT="1>"
+export REDERR="2>"
+
+export SENDECF="NO"
+export SENDCOM="NO"
+export SENDDBN="NO"
+export SENDSDM="NO"
+
+# Include GSDChem coupling: off:0, on:1 !lzhang
+export GSDChem=1
+export EMITYPE=2 # 1: MODIS, 2: GBBEPx 
+
+
+# Resolution specific parameters
+export LEVS=65                                                 ## JKH
+export CASE="@CASECTL@"
+export CASE_ENKF="@CASEENS@"
+
+# Surface cycle update frequency
+if [[ "$CDUMP" == "gdas" ]] ; then
+   export FHCYC=1
+   export FTSFS=10
+elif [[ "$CDUMP" == "gfs" ]] ; then
+   if [[ "$CCPP_SUITE" == "FV3_GSD_v0" ]] ; then
+       export FHCYC=0
+   else
+       export FHCYC=24
+   fi
+fi
+
+# Output frequency of the forecast model (for cycling)
+export FHMIN=0
+export FHMAX=9
+export FHOUT=3
+
+# Cycle to run EnKF  (set to BOTH for both gfs and gdas)
+export EUPD_CYC="gdas"
+
+# GFS cycle info
+export gfs_cyc=@gfs_cyc@ # 0: no GFS cycle, 1: 00Z only, 2: 00Z and 12Z only, 4: all 4 cycles.
+
+# GFS output and frequency
+export FHMIN_GFS=0
+
+export FHMAX_GFS_00=168                                      ## JKH
+export FHMAX_GFS_06=168                                      ## JKH
+export FHMAX_GFS_12=168                                      ## JKH
+export FHMAX_GFS_18=168                                      ## JKH
+export FHMAX_GFS=$(eval echo \${FHMAX_GFS_$cyc})
+
+export FHOUT_GFS=6                                           ## JKH
+export FHMAX_HF_GFS=0
+export FHOUT_HF_GFS=1
+export ILPOST=1           # gempak output frequency up to F120
+
+# GFS restart interval in hours
+export restart_interval_gfs=0
+
+
+# I/O QUILTING, true--use Write Component; false--use GFDL FMS
+# if quilting=true, choose OUTPUT_GRID as cubed_sphere_grid in netcdf or gaussian_grid
+# if gaussian_grid, set OUTPUT_FILE for nemsio or netcdf
+# WRITE_DOPOST=true, use inline POST
+export QUILTING=".true."
+export OUTPUT_GRID="gaussian_grid"
+export OUTPUT_FILE="nemsio"               ## JKH
+export WRITE_DOPOST=".true."
+
+# suffix options depending on file format
+if [ $OUTPUT_FILE = "netcdf" ]; then
+    export SUFFIX=".nc"
+    export NEMSIO_IN=".false."
+    export NETCDF_IN=".true."
+else
+    export SUFFIX=".nemsio"
+    export NEMSIO_IN=".true."
+    export NETCDF_IN=".false."
+fi
+
+# IAU related parameters
+export DOIAU="NO"        # Enable 4DIAU for control with 3 increments        ## JKH
+export IAUFHRS="3,6,9"
+export IAU_FHROT=`echo $IAUFHRS | cut -c1`
+export IAU_DELTHRS=6
+export IAU_OFFSET=6
+export DOIAU_ENKF="NO"   # Enable 4DIAU for EnKF ensemble                    ## JKH
+export IAUFHRS_ENKF="3,6,9"
+export IAU_DELTHRS_ENKF=6
+#if [[ "$SDATE" = "$CDATE" ]]; then
+if [[ "$SDATE" = "$CDATE" ]] || [[ "$DOIAU" = "NO" ]]; then
+  export IAU_OFFSET=0
+  export IAU_FHROT=0
+fi
+
+# Use Jacobians in eupd and thereby remove need to run eomg
+export lobsdiag_forenkf=".true."
+
+# run GLDAS to spin up land ICs
+export DO_GLDAS="NO"                                                       ## JKH
+export gldas_cyc=00
+
+# run wave component
+export DO_WAVE="NO"                                                        ## JKH
+export WAVE_CDUMP="both"
+
+# Microphysics Options: 99-ZhaoCarr, 8-Thompson; 6-WSM6, 10-MG, 11-GFDL
+if [[ "$CCPP_SUITE" == "FV3_GSD_v0" || "$CCPP_SUITE" == "FV3_GSD_noah" ]] ; then
+       export imp_physics=8
+else
+       export imp_physics=11
+fi
+
+# Shared parameters
+# Hybrid related
+export DOHYBVAR="YES"
+export NMEM_ENKF=@NMEM_ENKF@
+export SMOOTH_ENKF="NO"
+export l4densvar=".true."
+export lwrite4danl=".true."
+
+# EnKF output frequency
+if [ $DOHYBVAR = "YES" ]; then
+    export FHMIN_ENKF=3
+    export FHMAX_ENKF=9
+    if [ $l4densvar = ".true." ]; then
+        export FHOUT=1
+        export FHOUT_ENKF=1
+    else
+        export FHOUT_ENKF=3
+    fi
+fi
+
+# turned on nsst in anal and/or fcst steps, and turn off rtgsst
+export DONST="YES"
+if [ $DONST = "YES" ]; then export FNTSFA="        "; fi
+
+# The switch to apply SST elevation correction or not
+export nst_anl=.true.
+
+# Analysis increments to zero in CALCINCEXEC
+#export INCREMENTS_TO_ZERO="'liq_wat_inc','icmr_inc'"   #v16
+export INCREMENTS_TO_ZERO="'delz_inc','clwmr_inc','icmr_inc'"   #v15
+
+if [ $OUTPUT_FILE = "nemsio" ]; then
+    export DO_CALC_INCREMENT="YES"
+    export DO_CALC_ANALYSIS="NO"
+fi
+
+# Stratospheric increments to zero
+#export INCVARS_ZERO_STRAT="'sphum_inc','liq_wat_inc','icmr_inc'"
+#export INCVARS_EFOLD="5"
+
+# Swith to generate netcdf or binary diagnostic files.  If not specified,
+# script default to binary diagnostic files.   Set diagnostic file
+# variables here since used in both DA and vrfy jobs
+export netcdf_diag=".true."
+export binary_diag=".false."
+
+# Verification options
+export DO_METP="NO"                  # Run MET+ jobs          ## JKH
+
+# Archiving options
+export HPSSARCH="YES"        # save data to HPSS archive
+export ARCH_CYC=00           # Archive data at this cycle for warm_start capability
+export ARCH_WARMICFREQ=4     # Archive frequency in days for warm_start capability
+export ARCH_FCSTICFREQ=1     # Archive frequency in days for gdas and gfs forecast-only capability
+
+export DELETE_COM_IN_ARCHIVE_JOB="YES"   # NO=retain ROTDIR.  YES default in arch.sh and earc.sh.
+
+echo "END: config.base"

--- a/FV3GFSwfm/rt_ccpp_c384/config.base.emc.dyn
+++ b/FV3GFSwfm/rt_ccpp_c384/config.base.emc.dyn
@@ -1,0 +1,294 @@
+#!/bin/ksh -x
+
+########## config.base ##########
+# Common to all steps
+
+echo "BEGIN: config.base"
+
+# Machine environment
+export machine="@MACHINE@"
+
+# EMC parallel or NCO production
+export RUN_ENVIR="emc"
+
+# Account, queue, etc.
+export ACCOUNT="@ACCOUNT@"
+export QUEUE="@QUEUE@"
+export QUEUE_ARCH="@QUEUE_ARCH@"
+
+# Project to use in mass store:
+HPSS_PROJECT=fim
+
+# Directories relative to installation areas:
+export HOMEgfs=@HOMEgfs@
+export PARMgfs=$HOMEgfs/parm
+export FIXgfs=$HOMEgfs/fix
+export USHgfs=$HOMEgfs/ush
+export UTILgfs=$HOMEgfs/util
+export EXECgfs=$HOMEgfs/exec
+export SCRgfs=$HOMEgfs/scripts
+
+########################################################################
+
+# GLOBAL static environment parameters
+export NWPROD="@NWPROD@"
+export DMPDIR="@DMPDIR@"
+export RTMFIX=$CRTM_FIX
+
+# USER specific paths
+export HOMEDIR="@HOMEDIR@"
+export STMP="@STMP@"
+export PTMP="@PTMP@"
+export NOSCRUB="@NOSCRUB@"
+
+# Base directories for various builds
+export BASE_GIT="@BASE_GIT@"
+export BASE_SVN="@BASE_SVN@"
+
+#### CCPP Suite
+#### export CCPP_SUITE="FV3_GSD_v0"        # GSDsuite 
+#### export CCPP_SUITE="FV3_GSD_noah"      # GSDsuite + NOAH LSM  
+#### export CCPP_SUITE="FV3_GFS_v16beta"   # EMC v16beta
+export CCPP_SUITE="FV3_GFS_v15_gsd_chem"            # EMC v15_gsd_chem , using newer ozone_2015
+#export CCPP_SUITE="FV3_GFS_2017_gfdlmp_gsd_chem"            # GSL:FV3_GFS_2017_gfdlmp_gsd_chem
+
+# Toggle to turn on/off GFS downstream processing.
+export DO_BUFRSND="YES"
+export DO_GEMPAK="NO"
+export DO_AWIPS="NO"
+
+# NO for retrospective parallel; YES for real-time parallel
+#  arch.sh uses REALTIME for MOS.  Need to set REALTIME=YES
+#  if want MOS written to HPSS.   Should update arch.sh to
+#  use RUNMOS flag (currently in config.vrfy)
+export REALTIME="YES"
+
+
+####################################################
+# DO NOT ADD MACHINE DEPENDENT STUFF BELOW THIS LINE
+# IF YOU HAVE TO MAKE MACHINE SPECIFIC CHANGES BELOW
+# FEEL FREE TO MOVE THEM ABOVE THIS LINE TO KEEP IT
+# CLEAR
+####################################################
+# Build paths relative to $HOMEgfs
+export HOMEgsi="$HOMEgfs"
+export FIXgsi="$HOMEgfs/fix/fix_gsi"
+export HOMEfv3gfs="$HOMEgfs/sorc/fv3gfs.fd"
+export HOMEpost="$HOMEgfs"
+export HOMEobsproc_prep="$BASE_GIT/obsproc/gfsv16b/obsproc_prep.iss70457.netcdfhistory"
+export HOMEobsproc_network="$BASE_GIT/obsproc/gfsv16b/obsproc_global.iss71402.supportGFSv16"
+export HOMEobsproc_global=$HOMEobsproc_network
+export BASE_VERIF="$BASE_SVN/verif/global/tags/vsdb"
+
+# CONVENIENT utility scripts and other environment parameters
+export NCP="/bin/cp -p"
+export NMV="/bin/mv"
+export NLN="/bin/ln -sf"
+export VERBOSE="YES"
+export KEEPDATA="YES"
+export CHGRP_CMD="chgrp rstprod"
+export NEMSIOGET="$HOMEgfs/exec/nemsio_get"
+export NCDUMP="$NETCDF/bin/ncdump"
+export NCLEN="$HOMEgfs/ush/getncdimlen"
+
+# Machine environment, jobs, and other utility scripts
+export BASE_ENV="$HOMEgfs/env"
+export BASE_JOB="$HOMEgfs/jobs/rocoto"
+
+# EXPERIMENT specific environment parameters
+export SDATE=@SDATE@
+export EDATE=@EDATE@
+export assim_freq=24                     ## JKH
+export PSLOT="@PSLOT@"
+export EXPDIR="@EXPDIR@/$PSLOT"
+export ROTDIR="@ROTDIR@/$PSLOT"
+export ROTDIR_DUMP="YES"                #Note: A value of "NO" does not currently work
+export DUMP_SUFFIX=""
+if [[ "$CDATE" -ge "2019092100" && "$CDATE" -le "2019110700" ]]; then
+    export DUMP_SUFFIX="p"              # Use dumps from NCO GFS v15.3 parallel
+fi
+export RUNDIR="$STMP/RUNDIRS/$PSLOT"
+export DATAROOT="$RUNDIR/$CDATE/$CDUMP"
+export ARCDIR="$NOSCRUB/archive/$PSLOT"
+export ICSDIR="@ICSDIR@"
+export ATARDIR="/BMC/$HPSS_PROJECT/1year/gsd-ccpp-chem/$PSLOT"
+
+# Commonly defined parameters in JJOBS
+export envir=${envir:-"prod"}
+export NET="gfs"
+export RUN=${RUN:-${CDUMP:-"gfs"}}
+export jlogfile="${EXPDIR}/logs/jlogfile"
+export ERRSCRIPT=${ERRSCRIPT:-'eval [[ $err = 0 ]]'}
+export LOGSCRIPT=${LOGSCRIPT:-""}
+#export ERRSCRIPT=${ERRSCRIPT:-"err_chk"}
+#export LOGSCRIPT=${LOGSCRIPT:-"startmsg"}
+export REDOUT="1>"
+export REDERR="2>"
+
+export SENDECF="NO"
+export SENDCOM="NO"
+export SENDDBN="NO"
+export SENDSDM="NO"
+
+# Include GSDChem coupling: off:0, on:1 !lzhang
+export GSDChem=1
+export EMITYPE=2 # 1: MODIS, 2: GBBEPx 
+
+
+# Resolution specific parameters
+export LEVS=65                                                 ## JKH
+export CASE="@CASECTL@"
+export CASE_ENKF="@CASEENS@"
+
+# Surface cycle update frequency
+if [[ "$CDUMP" == "gdas" ]] ; then
+   export FHCYC=1
+   export FTSFS=10
+elif [[ "$CDUMP" == "gfs" ]] ; then
+   if [[ "$CCPP_SUITE" == "FV3_GSD_v0" ]] ; then
+       export FHCYC=0
+   else
+       export FHCYC=24
+   fi
+fi
+
+# Output frequency of the forecast model (for cycling)
+export FHMIN=0
+export FHMAX=9
+export FHOUT=3
+
+# Cycle to run EnKF  (set to BOTH for both gfs and gdas)
+export EUPD_CYC="gdas"
+
+# GFS cycle info
+export gfs_cyc=@gfs_cyc@ # 0: no GFS cycle, 1: 00Z only, 2: 00Z and 12Z only, 4: all 4 cycles.
+
+# GFS output and frequency
+export FHMIN_GFS=0
+
+export FHMAX_GFS_00=168                                      ## JKH
+export FHMAX_GFS_06=168                                      ## JKH
+export FHMAX_GFS_12=168                                      ## JKH
+export FHMAX_GFS_18=168                                      ## JKH
+export FHMAX_GFS=$(eval echo \${FHMAX_GFS_$cyc})
+
+export FHOUT_GFS=6                                           ## JKH
+export FHMAX_HF_GFS=0
+export FHOUT_HF_GFS=1
+export ILPOST=1           # gempak output frequency up to F120
+
+# GFS restart interval in hours
+export restart_interval_gfs=0
+
+
+# I/O QUILTING, true--use Write Component; false--use GFDL FMS
+# if quilting=true, choose OUTPUT_GRID as cubed_sphere_grid in netcdf or gaussian_grid
+# if gaussian_grid, set OUTPUT_FILE for nemsio or netcdf
+# WRITE_DOPOST=true, use inline POST
+export QUILTING=".true."
+export OUTPUT_GRID="gaussian_grid"
+export OUTPUT_FILE="nemsio"               ## JKH
+export WRITE_DOPOST=".true."
+
+# suffix options depending on file format
+if [ $OUTPUT_FILE = "netcdf" ]; then
+    export SUFFIX=".nc"
+    export NEMSIO_IN=".false."
+    export NETCDF_IN=".true."
+else
+    export SUFFIX=".nemsio"
+    export NEMSIO_IN=".true."
+    export NETCDF_IN=".false."
+fi
+
+# IAU related parameters
+export DOIAU="NO"        # Enable 4DIAU for control with 3 increments        ## JKH
+export IAUFHRS="3,6,9"
+export IAU_FHROT=`echo $IAUFHRS | cut -c1`
+export IAU_DELTHRS=6
+export IAU_OFFSET=6
+export DOIAU_ENKF="NO"   # Enable 4DIAU for EnKF ensemble                    ## JKH
+export IAUFHRS_ENKF="3,6,9"
+export IAU_DELTHRS_ENKF=6
+#if [[ "$SDATE" = "$CDATE" ]]; then
+if [[ "$SDATE" = "$CDATE" ]] || [[ "$DOIAU" = "NO" ]]; then
+  export IAU_OFFSET=0
+  export IAU_FHROT=0
+fi
+
+# Use Jacobians in eupd and thereby remove need to run eomg
+export lobsdiag_forenkf=".true."
+
+# run GLDAS to spin up land ICs
+export DO_GLDAS="NO"                                                       ## JKH
+export gldas_cyc=00
+
+# run wave component
+export DO_WAVE="NO"                                                        ## JKH
+export WAVE_CDUMP="both"
+
+# Microphysics Options: 99-ZhaoCarr, 8-Thompson; 6-WSM6, 10-MG, 11-GFDL
+if [[ "$CCPP_SUITE" == "FV3_GSD_v0" || "$CCPP_SUITE" == "FV3_GSD_noah" ]] ; then
+       export imp_physics=8
+else
+       export imp_physics=11
+fi
+
+# Shared parameters
+# Hybrid related
+export DOHYBVAR="YES"
+export NMEM_ENKF=@NMEM_ENKF@
+export SMOOTH_ENKF="NO"
+export l4densvar=".true."
+export lwrite4danl=".true."
+
+# EnKF output frequency
+if [ $DOHYBVAR = "YES" ]; then
+    export FHMIN_ENKF=3
+    export FHMAX_ENKF=9
+    if [ $l4densvar = ".true." ]; then
+        export FHOUT=1
+        export FHOUT_ENKF=1
+    else
+        export FHOUT_ENKF=3
+    fi
+fi
+
+# turned on nsst in anal and/or fcst steps, and turn off rtgsst
+export DONST="YES"
+if [ $DONST = "YES" ]; then export FNTSFA="        "; fi
+
+# The switch to apply SST elevation correction or not
+export nst_anl=.true.
+
+# Analysis increments to zero in CALCINCEXEC
+#export INCREMENTS_TO_ZERO="'liq_wat_inc','icmr_inc'"   #v16
+export INCREMENTS_TO_ZERO="'delz_inc','clwmr_inc','icmr_inc'"   #v15
+
+if [ $OUTPUT_FILE = "nemsio" ]; then
+    export DO_CALC_INCREMENT="YES"
+    export DO_CALC_ANALYSIS="NO"
+fi
+
+# Stratospheric increments to zero
+#export INCVARS_ZERO_STRAT="'sphum_inc','liq_wat_inc','icmr_inc'"
+#export INCVARS_EFOLD="5"
+
+# Swith to generate netcdf or binary diagnostic files.  If not specified,
+# script default to binary diagnostic files.   Set diagnostic file
+# variables here since used in both DA and vrfy jobs
+export netcdf_diag=".true."
+export binary_diag=".false."
+
+# Verification options
+export DO_METP="NO"                  # Run MET+ jobs          ## JKH
+
+# Archiving options
+export HPSSARCH="YES"        # save data to HPSS archive
+export ARCH_CYC=00           # Archive data at this cycle for warm_start capability
+export ARCH_WARMICFREQ=4     # Archive frequency in days for warm_start capability
+export ARCH_FCSTICFREQ=1     # Archive frequency in days for gdas and gfs forecast-only capability
+
+export DELETE_COM_IN_ARCHIVE_JOB="YES"   # NO=retain ROTDIR.  YES default in arch.sh and earc.sh.
+
+echo "END: config.base"

--- a/FV3GFSwfm/rt_ccpp_c384/config.base.nco.static
+++ b/FV3GFSwfm/rt_ccpp_c384/config.base.nco.static
@@ -1,0 +1,233 @@
+#!/bin/ksh -x
+
+########## config.base ##########
+# Common to all steps
+
+echo "BEGIN: config.base"
+
+# Machine environment
+export machine="WCOSS_DELL_P3"
+
+# EMC parallel or NCO production
+export RUN_ENVIR="nco"
+
+# Account, queue, etc.
+export ACCOUNT="FV3GFS-T2O"
+export QUEUE="prod"
+export QUEUE_ARCH="dev_transfer"
+
+# Project to use in mass store:
+HPSS_PROJECT=emc-global
+
+# Directories relative to installation areas:
+export PARMgfs=$HOMEgfs/parm
+export FIXgfs=$HOMEgfs/fix
+export USHgfs=$HOMEgfs/ush
+export UTILgfs=$HOMEgfs/util
+export EXECgfs=$HOMEgfs/exec
+export SCRgfs=$HOMEgfs/scripts
+
+########################################################################
+
+# GLOBAL static environment parameters
+
+export NWPROD="/gpfs/dell1/nco/ops/nwprod"
+export DMPDIR="/gpfs/dell3/emc/global/dump"
+export RTMFIX=$CRTM_FIX
+
+
+# Machine specific paths used everywhere
+
+# USER specific paths
+#    export HOMEDIR="/gpfs/dell2/emc/modeling/noscrub/$USER"
+    export HOMEDIR=$EXPDIR/HOMEDIR
+#    export STMP="/gpfs/dell3/stmp/$USER"
+    export STMP=$DATAROOT
+#    export PTMP="/gpfs/dell3/ptmp/$USER"
+    export PTMP=$ROTDIR
+#    export NOSCRUB="/gpfs/dell2/emc/modeling/noscrub/$USER"
+    export NOSCRUB=$EXPDIR/NOSCRUB
+
+    # Base directories for various builds
+    export BASE_GIT="/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git"
+    export BASE_SVN="/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git"
+
+
+# Toggle to turn on/off GFS downstream processing.
+export DO_BUFRSND="YES"
+export DO_GEMPAK="YES"
+export DO_AWIPS="YES"
+
+# NO for retrospective parallel; YES for real-time parallel
+export REALTIME="YES"
+
+
+####################################################
+# DO NOT ADD MACHINE DEPENDENT STUFF BELOW THIS LINE
+# IF YOU HAVE TO MAKE MACHINE SPECIFIC CHANGES BELOW
+# FEEL FREE TO MOVE THEM ABOVE THIS LINE TO KEEP IT
+# CLEAR
+####################################################
+# Build paths relative to $HOMEgfs
+export HOMEgsi="$HOMEgfs"
+export FIXgsi="$HOMEgfs/fix/fix_gsi"
+export HOMEfv3gfs="$HOMEgfs/sorc/fv3gfs.fd"
+export HOMEpost="$HOMEgfs"
+export HOMEobsproc_prep="$BASE_GIT/obsproc/obsproc_prep.iss-46886.fv3gfs"
+export HOMEobsproc_network="$BASE_GIT/obsproc/obsproc_global.iss-46886.fv3gfs"
+export BASE_VERIF="$BASE_SVN/verif/global/tags/vsdb"
+
+# CONVENIENT utility scripts and other environment parameters
+export NCP="/bin/cp -p"
+export NMV="/bin/mv"
+export NLN="/bin/ln -sf"
+export VERBOSE="YES"
+export KEEPDATA="NO"
+export CHGRP_CMD="chgrp rstprod"
+export NEMSIOGET="$HOMEgfs/exec/nemsio_get"
+
+# Machine environment, jobs, and other utility scripts
+export BASE_ENV="$HOMEgfs/env"
+export BASE_JOB="$HOMEgfs/jobs/rocoto"
+
+# EXPERIMENT specific environment parameters
+export SDATE=2018080600
+export EDATE=2039123100
+export assim_freq=6
+export PSLOT="rtecffv3"
+export EXPDIR="$EXPDIR"
+export ROTDIR="$ROTDIR"
+export ROTDIR_DUMP="YES"
+export DUMP_SUFFIX=""
+export RUNDIR="$DATAROOT"
+export ARCDIR="$NOSCRUB/archive/$PSLOT"
+export ICSDIR="/gpfs/dell2/ptmp/$USER/FV3ICS"
+export ATARDIR="/NCEPDEV/$HPSS_PROJECT/1year/$USER/$machine/scratch/$PSLOT"
+
+# Commonly defined parameters in JJOBS
+export envir=${envir:-"prod"}
+export NET="gfs"
+export RUN=${RUN:-${CDUMP:-"gfs"}}
+export ERRSCRIPT=${ERRSCRIPT:-'eval [[ $err = 0 ]]'}
+export LOGSCRIPT=${LOGSCRIPT:-""}
+#export ERRSCRIPT=${ERRSCRIPT:-"err_chk"}
+#export LOGSCRIPT=${LOGSCRIPT:-"startmsg"}
+export REDOUT="1>"
+export REDERR="2>"
+
+export SENDECF=${SENDECF:-"NO"}
+export SENDCOM=${SENDCOM:-"YES"}
+export SENDDBN=${SENDDBN:-"YES"}
+export SENDSDM=${SENDSDM:-"NO"}
+
+# Resolution specific parameters
+export LEVS=128
+export CASE="C768"
+export CASE_ENKF="C384"
+
+# Surface cycle update frequency
+if [[ "$CDUMP" == "gdas" ]] ; then
+   export FHCYC=1
+   export FTSFS=10
+elif [[ "$CDUMP" == "gfs" ]] ; then
+   export FHCYC=24
+fi
+
+# Output frequency of the forecast model (for cycling)
+export FHMIN=0
+export FHMAX=9
+export FHOUT=3
+
+# GFS cycle info
+export gfs_cyc=4 # 0: no GFS cycle, 1: 00Z only, 2: 00Z and 12Z only, 4: all 4 cycles.
+
+# GFS output and frequency
+export FHMIN_GFS=0
+
+export FHMAX_GFS_00=384
+export FHMAX_GFS_06=384
+export FHMAX_GFS_12=384
+export FHMAX_GFS_18=384
+export FHMAX_GFS=$(eval echo \${FHMAX_GFS_$cyc})
+
+export FHOUT_GFS=3
+export FHMAX_HF_GFS=120
+export FHOUT_HF_GFS=1
+
+# frequency for saving restart files. set to 6,12,24,48 etc 
+export restart_interval_gfs=12
+
+
+# I/O QUILTING, true--use Write Component; false--use GFDL FMS
+# if quilting=true, choose OUTPUT_GRID as cubed_sphere_grid in netcdf or gaussian_grid
+# if gaussian_grid, set OUTPUT_FILE for nemsio or netcdf
+# WRITE_DOPOST=true, use inline POST
+export QUILTING=".true."
+export OUTPUT_GRID="gaussian_grid"
+export OUTPUT_FILE="nemsio"
+export WRITE_DOPOST=".true."
+
+# IAU related parameters
+export DOIAU="NO"
+export IAUFHRS=6
+export IAU_FHROT=`echo $IAUFHRS | cut -c1`
+export IAU_DELTHRS=6
+export DOIAU_ENKF="NO"
+export IAUFHRS_ENKF=6
+export IAU_DELTHRS_ENKF=6
+if [[ "$SDATE" = "$CDATE" ]]; then
+  export IAU_OFFSET=0
+  export IAU_FHROT=0
+fi
+
+# run GLDAS to spin up land ICs
+export DO_GLDAS=YES
+export gldas_cyc=00
+
+# run wave component
+export DO_WAVE=YES
+
+# Microphysics Options: 99-ZhaoCarr, 8-Thompson; 6-WSM6, 10-MG, 11-GFDL
+export imp_physics=11
+
+# Shared parameters
+# Hybrid related
+export DOHYBVAR="YES"
+export NMEM_ENKF=80
+export SMOOTH_ENKF="NO"
+export l4densvar=".true."
+export lwrite4danl=".false."
+
+# EnKF output frequency
+if [ $DOHYBVAR = "YES" ]; then
+    export FHMIN_ENKF=3
+    export FHMAX_ENKF=9
+    if [ $l4densvar = ".true." ]; then
+        export FHOUT=1
+        export FHOUT_ENKF=1
+    else
+        export FHOUT_ENKF=3
+    fi
+fi
+
+# turned on nsst in anal and/or fcst steps, and turn off rtgsst
+
+export DONST="YES"
+if [ $DONST = "YES" ]; then export FNTSFA="        "; fi
+
+# The switch to apply SST elevation correction or not
+export nst_anl=.true.
+
+# Analysis increments to zero in CALCINCEXEC
+export INCREMENTS_TO_ZERO="'delz_inc','clwmr_inc','icmr_inc'"
+
+
+# Archiving options
+export DELETE_COM_IN_ARCHIVE_JOB=YES
+export HPSSARCH="NO"         # save data to HPSS archive
+export ARCH_CYC=00           # Archive data at this cycle for warm_start capability
+export ARCH_WARMICFREQ=1     # Archive frequency in days for warm_start capability
+export ARCH_FCSTICFREQ=1     # Archive frequency in days for gdas and gfs forecast-only capability
+
+
+echo "END: config.base"

--- a/FV3GFSwfm/rt_ccpp_c384/config.calcinc
+++ b/FV3GFSwfm/rt_ccpp_c384/config.calcinc
@@ -1,0 +1,21 @@
+#!/bin/ksh -x
+
+########## config.calcinc ##########
+# CALCINC specific configuration
+
+echo "BEGIN: config.calcinc"
+
+# Get task specific resources
+. $EXPDIR/config.resources calcinc
+
+
+# Set calcinc variables 
+
+# Set job and DATAROOT
+export job=${CDUMP}_calcinc_${cyc}
+export DATA="$RUNDIR/$CDATE/$CDUMP"
+export NTHREADS_CALCINC=1
+export ncmd=1
+export DO_CALC_INCREMENT="YES"
+
+echo "END: config.calcinc"

--- a/FV3GFSwfm/rt_ccpp_c384/config.earc
+++ b/FV3GFSwfm/rt_ccpp_c384/config.earc
@@ -1,0 +1,13 @@
+#!/bin/ksh -x
+
+########## config.earc ##########
+# Ensemble archive specific
+
+echo "BEGIN: config.earc"
+
+# Get task specific resources
+. $EXPDIR/config.resources earc
+
+export NMEM_EARCGRP=10
+
+echo "END: config.earc"

--- a/FV3GFSwfm/rt_ccpp_c384/config.ecen
+++ b/FV3GFSwfm/rt_ccpp_c384/config.ecen
@@ -1,0 +1,25 @@
+#!/bin/ksh -x
+
+########## config.ecen ##########
+# Ensemble recentering specific
+
+echo "BEGIN: config.ecen"
+
+# Get task specific resources
+. $EXPDIR/config.resources ecen
+
+export ENKFRECENSH="$HOMEgsi/scripts/exglobal_enkf_recenter_fv3gfs.sh.ecf"
+
+export CHGRESEXEC="$HOMEgfs/exec/chgres_recenter.exe"
+
+# Number of concurrent ecen jobs [1 implies sequential]
+# Usually IAUFHRS_ENKF=3,6,9, so NECENGRP=3.  Scripting
+# below queries IAUFHRS_ENKF to determine NECENGRP
+export NECENGRP=1
+if [ $DOIAU_ENKF = "YES" ]; then
+   ngrps=$(grep -o ',' <<<"$IAUFHRS_ENKF" | grep -c .)
+   ((ngrps++))
+   export NECENGRP=$ngrps
+fi
+
+echo "END: config.ecen"

--- a/FV3GFSwfm/rt_ccpp_c384/config.echgres
+++ b/FV3GFSwfm/rt_ccpp_c384/config.echgres
@@ -1,0 +1,13 @@
+#!/bin/ksh -x
+
+########## config.echgres ##########
+# regrid full-res forecast for use in ensemble-res analysis generation
+
+echo "BEGIN: config.echgres"
+
+# Get task specific resources
+. $EXPDIR/config.resources echgres
+
+export CHGRESFCSTSH=$HOMEgfs/scripts/exglobal_enkf_chgres_fv3gfs.sh.ecf
+
+echo "END: config.echgres"

--- a/FV3GFSwfm/rt_ccpp_c384/config.ediag
+++ b/FV3GFSwfm/rt_ccpp_c384/config.ediag
@@ -1,0 +1,11 @@
+#!/bin/ksh -x
+
+########## config.ediag ##########
+# GFS ensemble post-eobs specific
+
+echo "BEGIN: config.ediag"
+
+# Get task specific resources
+. $EXPDIR/config.resources ediag
+
+echo "END: config.ediag"

--- a/FV3GFSwfm/rt_ccpp_c384/config.efcs
+++ b/FV3GFSwfm/rt_ccpp_c384/config.efcs
@@ -1,0 +1,94 @@
+#!/bin/ksh -x
+
+########## config.efcs ##########
+# Ensemble forecast specific, dependency: config.fcst
+
+echo "BEGIN: config.efcs"
+
+# Source model specific information that is resolution dependent
+. $EXPDIR/config.fv3 $CASE_ENKF
+
+# Get task specific resources
+. $EXPDIR/config.resources efcs
+
+export npe_fv3=$npe_efcs
+
+if [ $QUILTING = ".true." ]; then
+    export npe_fv3=$(echo " $npe_fv3 + $WRITE_GROUP * $WRTTASK_PER_GROUP" | bc)
+    export npe_efcs=$npe_fv3
+fi
+
+export ENKFFCSTSH="$HOMEgsi/scripts/exglobal_enkf_fcst_fv3gfs.sh.ecf"
+export NMEM_EFCSGRP=2
+export RERUN_EFCSGRP="NO"
+
+# Turn off inline UPP for EnKF forecast
+export WRITE_DOPOST=".false."
+
+# Stochastic physics parameters (only for ensemble forecasts)
+export DO_SKEB="YES"
+export SKEB=0.3
+export SKEB_TAU=21600.
+export SKEB_LSCALE=250000.
+export SKEBNORM=0
+export SKEB_NPASS=30
+export SKEB_VDOF=5
+export DO_SHUM="YES"
+export SHUM=0.005
+export SHUM_TAU=21600.
+export SHUM_LSCALE=500000.
+export DO_SPPT="YES"
+export SPPT=0.5
+export SPPT_TAU=21600.
+export SPPT_LSCALE=500000.
+export SPPT_LOGIT=".true."
+export SPPT_SFCLIMIT=".true."
+
+if [ $QUILTING = ".true." -a $OUTPUT_GRID = "gaussian_grid" ]; then
+    if [[ "$CCPP_SUITE" == "FV3_GSD_v0" || "$CCPP_SUITE" == "FV3_GSD_noah" ]] ; then
+      export DIAG_TABLE="$HOMEgfs/parm/parm_fv3diag/diag_table_da_gsd"
+    else
+      export DIAG_TABLE="$HOMEgfs/parm/parm_fv3diag/diag_table_da"
+    fi
+else
+    export DIAG_TABLE="$HOMEgfs/parm/parm_fv3diag/diag_table_da_orig"
+fi
+
+# FV3 model namelist parameters to over-ride
+export restart_interval=${restart_interval:-6}
+
+# For IAU, write restarts at beginning of window also
+if [ $DOIAU_ENKF = "YES" ]; then
+    export restart_interval="6 -1"
+    if [[ "$SDATE" = "$CDATE" ]]; then export restart_interval="3 -1"; fi
+fi
+
+export OUTPUT_FILETYPES="$OUTPUT_FILE"
+if [[ "$OUTPUT_FILE" == "netcdf" ]]; then
+    export  ichunk2d=0; export jchunk2d=0
+    export  ichunk3d=0; export jchunk3d=0;  export kchunk3d=0
+    RESTILE=`echo $CASE_ENKF |cut -c 2-`
+    if [[ "$machine" == "WCOSS_DELL_P3" ]]; then
+        if [ $RESTILE -ge 384 ]; then
+            export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
+            export ichunk2d=$((4*RESTILE))
+            export jchunk2d=$((2*RESTILE))
+            export ichunk3d=$((4*RESTILE))
+            export jchunk3d=$((2*RESTILE))
+            export kchunk3d=1
+        else
+            export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
+        fi
+    fi
+    if [[ "$machine" == "HERA" ]]; then
+        export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf_parallel' "
+        if [ $RESTILE -le 192 ]; then
+            export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
+        fi
+    fi
+fi
+
+# wave model
+export cplwav=.false.
+
+echo "END: config.efcs"

--- a/FV3GFSwfm/rt_ccpp_c384/config.eobs
+++ b/FV3GFSwfm/rt_ccpp_c384/config.eobs
@@ -1,0 +1,32 @@
+#!/bin/ksh -x
+
+########## config.eobs config.eomg ##########
+# Ensemble innovation specific, dependency config.anal
+
+echo "BEGIN: config.eobs"
+
+# Get task specific resources
+. $EXPDIR/config.resources eobs
+
+export INVOBSSH="$HOMEgsi/scripts/exglobal_innovate_obs_fv3gfs.sh.ecf"
+export ENKFINVOBSSH="$HOMEgsi/scripts/exglobal_enkf_innovate_obs_fv3gfs.sh.ecf"
+export NMEM_EOMGGRP=8  
+export RERUN_EOMGGRP="YES"
+export npe_gsi=$npe_eobs
+
+# GSI namelist options related to observer for EnKF
+export OBSINPUT_INVOBS="dmesh(1)=225.0,dmesh(2)=225.0"
+export OBSQC_INVOBS="tcp_width=60.0,tcp_ermin=2.0,tcp_ermax=12.0"
+if [ $LEVS = "128" ]; then
+   export GRIDOPTS_INVOBS="nlayers(63)=1,nlayers(64)=1,"
+   export SETUP_INVOBS="gpstop=55,nsig_ext=56,"
+fi
+
+
+export USE_RADSTAT="NO" # This can be only used when bias correction is non-zero.
+export GENDIAG="YES"    # Diagnostic files must be created for EnKF
+
+export lobsdiag_forenkf=".true."  # write out jacobians from eobs
+                                  # need to specify .true. setting since config.anal sets to .false.
+
+echo "END: config.eobs"

--- a/FV3GFSwfm/rt_ccpp_c384/config.epos
+++ b/FV3GFSwfm/rt_ccpp_c384/config.epos
@@ -1,0 +1,22 @@
+#!/bin/ksh -x
+
+########## config.epos ##########
+# Ensemble post processing specific
+
+echo "BEGIN: config.epos"
+
+# Get task specific resources
+. $EXPDIR/config.resources epos
+
+export ENKFPOSTSH="$HOMEgsi/scripts/exglobal_enkf_post_fv3gfs.sh.ecf"
+
+# No. of concurrent epos jobs [1 implies sequential]
+export NEPOSGRP=7
+if [ $l4densvar = ".false." ]; then
+    export NEPOSGRP=3
+fi
+
+# Generate ensemble spread files
+export ENKF_SPREAD="YES"
+
+echo "END: config.epos"

--- a/FV3GFSwfm/rt_ccpp_c384/config.esfc
+++ b/FV3GFSwfm/rt_ccpp_c384/config.esfc
@@ -1,0 +1,21 @@
+#!/bin/ksh -x
+
+########## config.esfc ##########
+# Ensemble surface specific
+
+echo "BEGIN: config.esfc"
+
+# Get task specific resources
+. $EXPDIR/config.resources esfc
+
+export ENKFRESFCSH="$HOMEgsi/scripts/exglobal_enkf_surface_fv3gfs.sh.ecf"
+
+# With IAU only need surface analysis at start of IAU window.
+# Set DOSFCANL_ENKF=NO to prevent creation of sfcanl at 
+# center of analysis window.  
+
+if [ $DOIAU_ENKF = "YES" ]; then
+   export DOSFCANL_ENKF="NO"
+fi
+
+echo "END: config.esfc"

--- a/FV3GFSwfm/rt_ccpp_c384/config.eupd
+++ b/FV3GFSwfm/rt_ccpp_c384/config.eupd
@@ -1,0 +1,35 @@
+#!/bin/ksh -x
+
+########## config.eupd ##########
+# Ensemble update specific, dependency config.anal
+
+echo "BEGIN: config.eupd"
+
+# Get task specific resources
+. $EXPDIR/config.resources eupd
+
+export ENKFUPDSH="$HOMEgsi/scripts/exglobal_enkf_update_fv3gfs.sh.ecf"
+export npe_enkf=$npe_eupd
+
+# Use NAM_ENKF below for serial EnKF
+##export NAM_ENKF="analpertwtnh=0.9,analpertwtsh=0.9,analpertwttr=0.9"
+
+# LETKF specific settings with model space localization
+export modelspace_vloc=".true."  # model space localization
+export letkf_flag=".true."       # use LETKF instead of serial filter
+export getkf=".true."            # Gain form of LETKF (needed for model-space localization)
+export denkf=".true."            # EnKF approximation (beneficial since less spread removed by analysis)
+export nobsl_max=10000           # max number of obs in each LETKF volume (uses closest nobsl_max). can
+                                 #  be reduced to speed up execution time.
+export analpertwt=0.85           # relaxation to prior spread inflation factor
+export readin_localization_enkf=".false." # Don’t read in localization scales from file (doesn’t make
+                                          # sense for LETKF if model space localization on and nobsl_max>0)
+export corrlength=1250           # Horizontal localization scale (max horizontal distance to search for nobsl_max local obs)
+export lnsigcutoff=2.75          # ignored if modelspace_vloc=.true.
+
+export lobsdiag_forenkf=".true." # use jacobian.  must be .true. if modelspace_vloc=".true."
+                                 # need to specify .true. setting since config.anal sets to .false.
+
+export NAM_ENKF="smoothparm=35,"
+
+echo "END: config.eupd"

--- a/FV3GFSwfm/rt_ccpp_c384/config.fcst
+++ b/FV3GFSwfm/rt_ccpp_c384/config.fcst
@@ -1,0 +1,353 @@
+#!/bin/ksh -x
+
+########## config.fcst ##########
+# Forecast specific
+
+echo "BEGIN: config.fcst"
+
+# Source model specific information that is resolution dependent
+. $EXPDIR/config.fv3 $CASE
+
+# Get task specific resources
+. $EXPDIR/config.resources fcst
+
+if [ $DONST = "YES" ]; then
+    . $EXPDIR/config.nsst
+fi
+
+export FORECASTSH="$HOMEgfs/scripts/exglobal_fcst_nemsfv3gfs_nochem.sh"
+export FCSTEXECDIR="$HOMEgfs/exec"
+export FCSTEXEC="global_fv3gfs_ccpp.x"
+export npe_fv3=$npe_fcst 
+
+if [[ "$CDUMP" == "gfs" ]] ; then
+   export npe_fv3=$npe_fcst_gfs
+   export layout_x=$layout_x_gfs
+   export layout_y=$layout_y_gfs
+   export WRITE_GROUP=$WRITE_GROUP_GFS
+   export WRTTASK_PER_GROUP=$WRTTASK_PER_GROUP_GFS
+fi
+
+if [ $QUILTING = ".true." ]; then
+    export npe_fv3=$(echo " $npe_fv3 + $WRITE_GROUP * $WRTTASK_PER_GROUP" | bc)
+    export npe_fcst=$npe_fv3
+    export npe_fcst_gfs=$(echo " $npe_fcst_gfs  + $WRITE_GROUP_GFS * $WRTTASK_PER_GROUP_GFS" | bc)
+fi
+
+if [ $DO_WAVE = "YES" ] ; then
+  export npe_fcst=$((npe_fcst + npe_wav))
+  if [ "$WAVE_CDUMP" = "gfs" -o "$WAVE_CDUMP" = "both" ]; then
+     export npe_fcst_gfs=$((npe_fcst_gfs + npe_wav_gfs))
+     if [ "$CDUMP" = "gfs" ]; then npe_wav=$npe_wav_gfs ; fi
+  fi
+fi
+
+# Model configuration
+export TYPE="nh"
+export MONO="non-mono"
+
+# Use stratosphere h2o physics
+export h2o_phys=".true."
+
+# Options of stratosphere O3 physics reaction coefficients
+export new_o3forc="YES"
+
+# do_ugwp=T: use unified CGWD and OGWD, and turbulent orographic form drag (TOFD)
+# do_ugwp=F: use unified CGWD but old OGWD, TOFD is not uded.
+export do_ugwp=".false."
+export do_tofd=".true."
+export launch_level=$(echo "$LEVS/2.35" |bc)
+
+# turn off chemistry
+export cplchm=.false.
+
+# Sponge layer settings for L127
+if [ $LEVS = "128" -a "$CDUMP" = "gdas" ]; then
+   export  tau=5.0
+   export  rf_cutoff=1.0e3
+   export  d2_bg_k1=0.20
+   export  d2_bg_k2=0.0
+fi
+
+# PBL/turbulence schemes
+export hybedmf=".true."
+if [[ "$CCPP_SUITE" == "FV3_GSD_v0" || "$CCPP_SUITE" == "FV3_GSD_noah" ]] ; then
+    export satmedmf=".false."
+    export isatmedmf=0
+    export shal_cnv=".true."       
+    export do_mynnedmf=".true."     
+    export do_mynnsfclay=".false."
+    export icloud_bl=1        
+    export bl_mynn_tkeadvect=.true. 
+    export bl_mynn_edmf=1        
+    export bl_mynn_edmf_mom=1
+else
+    export satmedmf=".false."   
+    export isatmedmf=1        
+fi
+
+tbf=""
+if [ $satmedmf = ".true." ]; then tbf="_satmedmf" ; fi
+
+# Land surface model. (3--RUCLSM, landice=F;) (2--NoahMP, landice=F); (1--Noah, landice=T)
+if [[ "$CCPP_SUITE" == "FV3_GSD_v0" ]]; then
+    export lsm=3
+    export lsoil_lsm=9
+else
+    export lsm=1
+fi
+
+if [ $lsm -eq 2 -o $lsm -eq 3 ]; then
+    export lheatstrg=".false."
+    export landice=".false."
+else
+    export lheatstrg=".false."    
+    if [[ "$CCPP_SUITE" == "FV3_GSD_v0" || "$CCPP_SUITE" == "FV3_GSD_noah" ]] ; then
+        export landice=".false."      ##JKH
+    else
+        export landice=".true."
+    fi
+fi
+
+# Radiation options 
+if [[ "$CCPP_SUITE" == "FV3_GSD_v0" || "$CCPP_SUITE" == "FV3_GSD_noah" ]] ; then
+    export IAER=111    ## JKH 
+    export iovr_lw=1   ## JKH 
+    export iovr_sw=1   ## JKH
+    export icliq_sw=1  ## JKH
+else
+    export IAER=5111    ;#spectral band mapping method for aerosol optical properties
+    export iovr_lw=3    ;#de-correlation length cloud overlap method (Barker, 2008)
+    export iovr_sw=3    ;#de-correlation length cloud overlap method (Barker, 2008)
+    export icliq_sw=2   ;#cloud optical coeffs from AER's newer version v3.9-v4.0 for hu and stamnes
+fi
+
+# CCPP configuration
+export output_1st_tstep_rst=".false."                                        #JKH
+
+# Convection Options: 2-SASAS, 3-GF
+if [[ "$CCPP_SUITE" == "FV3_GSD_v0" || "$CCPP_SUITE" == "FV3_GSD_noah" ]] ; then
+	export imfdeepcnv=3
+	export imfshalcnv=3
+else
+	export imfdeepcnv=2
+	export imfshalcnv=2
+fi
+
+# Microphysics configuration
+export dnats=0
+export cal_pre=".true."
+export do_sat_adj=".false."
+export random_clds=".true."
+
+if [ $imp_physics -eq 99 ]; then # ZhaoCarr
+    export ncld=1
+    #export FIELD_TABLE="$HOMEgfs/parm/parm_fv3diag/field_table_zhaocarr" !lzhang
+    export FIELD_TABLE="$HOMEgfs/parm/parm_fv3diag/chm_field_table"
+    export nwat=2
+
+elif [ $imp_physics -eq 6 ]; then # WSM6
+    export ncld=2
+    export FIELD_TABLE="$HOMEgfs/parm/parm_fv3diag/field_table_wsm6${tbf}"
+    export nwat=6
+
+elif [ $imp_physics -eq 8 ]; then # Thompson
+    export nwat=6
+    if [[ "$CCPP_SUITE" == "FV3_GSD_v0" || "$CCPP_SUITE" == "FV3_GSD_noah" ]] ; then
+        export ncld=5
+        export FIELD_TABLE="$HOMEgfs/parm/parm_fv3diag/field_table_gsd"
+        export ltaerosol=.true.                  
+        export lradar=.true.         
+    
+        ## GSD namelist changes
+        export cal_pre=".false."
+        export random_clds=".false."
+        export effr_in=.true.
+        export ttendlim=0.005
+        export vtdm4_nh_nonmono=0.02
+        export nord=2
+        export dddmp=0.1
+        export d4_bg=0.12
+    else
+        export ncld=2
+        export FIELD_TABLE="$HOMEgfs/parm/parm_fv3diag/field_table_thompson${tbf}"
+    fi
+
+elif [ $imp_physics -eq 11 ]; then # GFDL
+    export ncld=5
+    export FIELD_TABLE="$HOMEgfs/parm/parm_fv3diag/field_table_gfdl_gsd"
+    export nwat=6
+    export dnats=1
+    export cal_pre=".false."
+    export do_sat_adj=".true."
+    export random_clds=".false."
+    export lgfdlmprad=".true."
+    export effr_in=".true."
+    export reiflag=2
+
+    export hord_mt_nh_nonmono=5
+    export hord_xx_nh_nonmono=5
+    export vtdm4_nh_nonmono=0.02
+    export nord=2
+    export dddmp=0.1
+    export d4_bg=0.12
+
+else
+    echo "Unknown microphysics option, ABORT!"
+
+fi
+#---------------------------------------------------------------------
+
+# ideflate: netcdf zlib lossless compression (0-9): 0 no compression
+# nbits: netcdf lossy compression level (0-32): 0 lossless
+export ideflate=1
+export nbits=14
+export ishuffle=0
+# compression for RESTART files written by FMS 
+export shuffle=1
+export deflate_level=1
+
+export OUTPUT_FILETYPES="$OUTPUT_FILE"
+if [[ "$OUTPUT_FILE" == "netcdf" ]]; then
+    export  ichunk2d=0; export jchunk2d=0
+    export  ichunk3d=0; export jchunk3d=0;  export kchunk3d=0
+    RESTILE=`echo $CASE |cut -c 2-`
+    if [[ "$machine" == "WCOSS_DELL_P3" ]]; then
+        if [ $RESTILE -ge 768 ]; then
+            export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf_parallel' "
+            export ichunk3d=$((4*RESTILE)) 
+            export jchunk3d=$((2*RESTILE))
+            export kchunk3d=1
+        else
+            export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
+        fi
+    fi
+    if [[ "$machine" == "HERA" ]]; then
+        export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf_parallel' "
+        if [ $RESTILE -le 192 ]; then
+            export OUTPUT_FILETYPES=" 'netcdf_parallel' 'netcdf' "
+        fi
+    fi
+fi
+
+
+#---------------------------------------------------------------------
+# Disable the use of coupler.res; get model start time from model_configure
+export USE_COUPLER_RES="NO"
+
+if [[ "$CDUMP" == "gdas" ]] ; then # GDAS cycle specific parameters
+
+    # Variables used in DA cycling
+    if [ $QUILTING = ".true." -a $OUTPUT_GRID = "gaussian_grid" ]; then
+        if [[ "$CCPP_SUITE" == "FV3_GSD_v0" || "$CCPP_SUITE" == "FV3_GSD_noah" ]] ; then
+          export DIAG_TABLE="$HOMEgfs/parm/parm_fv3diag/diag_table_da_gsd"
+        else
+          export DIAG_TABLE="$HOMEgfs/parm/parm_fv3diag/diag_table_da"
+        fi
+    else
+        export DIAG_TABLE="$HOMEgfs/parm/parm_fv3diag/diag_table_da_orig"
+    fi
+
+    # Write restart files, where $number is current model start time. 
+    # restart_interval:        $number
+    #    number=0, writes out restart files at the end of forecast. 
+    #    number>0, writes out restart files at the frequency of $number and at the end of forecast.
+    # restart_interval:        "$number -1"
+    #    writes out restart files only once at $number forecast hour.
+    # restart_interval:        "$number1 $number2 $number3 ..."
+    #    writes out restart file at the specified forecast hours 
+    export restart_interval=${restart_interval:-6}
+
+    # For IAU, write restarts at beginning of window also
+    if [ $DOIAU = "YES" ]; then
+       export restart_interval="6 9"
+       if [[ "$SDATE" = "$CDATE" ]]; then export restart_interval="3 6"; fi
+    fi
+
+    # Choose coupling with wave
+    if [ $DO_WAVE = "YES" ]; then export cplwav=".true." ; fi
+
+    # Turn on dry mass adjustment in GDAS
+    export adjust_dry_mass=".true."
+
+elif [[ "$CDUMP" == "gfs" ]] ; then # GFS cycle specific parameters
+
+    # Write more variables to output
+    if [ $QUILTING = ".true." -a $OUTPUT_GRID = "gaussian_grid" ]; then
+        if [[ "$CCPP_SUITE" == "FV3_GSD_v0" ]]; then
+            export DIAG_TABLE="$HOMEgfs/parm/parm_fv3diag/diag_table_gsd_ruc"
+        elif [[ "$CCPP_SUITE" == "FV3_GSD_noah" ]]; then
+            export DIAG_TABLE="$HOMEgfs/parm/parm_fv3diag/diag_table_gsd"
+        else
+            #export DIAG_TABLE="$HOMEgfs/parm/parm_fv3diag/diag_table" #lzhang
+            export DIAG_TABLE="$HOMEgfs/parm/parm_fv3diag/chm_diag_table" 
+        fi
+    else
+        #export DIAG_TABLE="$HOMEgfs/parm/parm_fv3diag/diag_table_orig"  !lzhang
+        export DIAG_TABLE="$HOMEgfs/parm/parm_fv3diag/chm_diag_table"
+    fi
+
+    # Write gfs restart files to rerun fcst from any break point         
+    export restart_interval_gfs=${restart_interval_gfs:-0}
+    if [ $restart_interval_gfs -le 0 ]; then
+        #export restart_interval=0
+        export restart_interval=24 #lzhang
+    else
+        rst_list=""
+        IAU_OFFSET=${IAU_OFFSET:-0}
+        [[ $DOIAU = "NO" ]] && export IAU_OFFSET=0
+        xfh=$((restart_interval_gfs+(IAU_OFFSET/2)))
+        while [ $xfh -le $FHMAX_GFS ]; do
+          rst_list="$rst_list $xfh"
+          xfh=$((xfh+restart_interval_gfs))
+        done
+        export restart_interval="$rst_list"
+    fi
+
+    
+    # Choose coupling with wave
+    if [ $DO_WAVE = "YES" -a "$WAVE_CDUMP" != "gdas" ]; then 
+        export cplwav=".true."
+    fi
+
+    # Turn off dry mass adjustment in GFS
+    export adjust_dry_mass=".false."
+
+    # Write each restart file in 16 small files to save time
+    #export io_layout="4,4"  #lzhang
+    export io_layout="1,1"
+
+    # Set number of layers from the top over 
+    # which two delta-Z filter is applied
+    if [ $LEVS = "128" ]; then export n_sponge=42; fi   #127 layer
+    if [ $LEVS = "65" ]; then export n_sponge=23; fi    # 64 layer
+
+    # Debug load balancing 
+    #export KEEPDATA="YES"
+    #export ESMF_RUNTIME_PROFILE=ON
+    #export ESMF_RUNTIME_PROFILE_OUTPUT=SUMMARY
+
+fi
+
+
+# Regrid tiles to global Gaussian grid in NEMSIO
+export REGRID_NEMSIO_SH="$HOMEgfs/ush/fv3gfs_regrid_nemsio.sh"
+if [ $DONST = YES ]; then
+    export REGRID_NEMSIO_TBL="$HOMEgfs/parm/parm_fv3diag/variable_table_da.txt"
+else
+    export REGRID_NEMSIO_TBL="$HOMEgfs/parm/parm_fv3diag/variable_table_da_nonsst.txt"
+fi
+
+# Remap tiles to global latlon grid in NetCDF
+export REMAPSH="$HOMEgfs/ush/fv3gfs_remap.sh"
+export master_grid="0p25deg"                   # 1deg 0p5deg 0p25deg 0p125deg etc
+export npe_remap=$((npe_fcst < 240 ? npe_fcst : 240))
+
+# Global latlon NetCDF to nemsio utility parameters
+export NC2NEMSIOSH="$HOMEgfs/ush/fv3gfs_nc2nemsio.sh"
+
+# Remember config.efcs will over-ride these values for ensemble forecasts
+# if these variables are re-defined there.
+# Otherwise, the ensemble forecast will inherit from config.fcst
+
+echo "END: config.fcst"

--- a/FV3GFSwfm/rt_ccpp_c384/config.fv3
+++ b/FV3GFSwfm/rt_ccpp_c384/config.fv3
@@ -1,0 +1,164 @@
+#!/bin/ksh -x
+
+########## config.fv3 ##########
+# FV3 model resolution specific parameters
+# e.g. time-step, processor layout, physics and dynamics parameters
+# This config sets default variables for FV3 for a given resolution
+# User can over-ride after sourcing this config file
+
+if [ $# -ne 1 ]; then
+
+    echo "Must specify an input resolution argument to set variables!"
+    echo "argument can be any one of the following:"
+    echo "C48 C96 C192 C384 C768 C1152 C3072"
+    exit 1
+
+fi
+
+case_in=$1
+
+echo "BEGIN: config.fv3"
+
+
+if [[ "$machine" = "WCOSS_DELL_P3" ]]; then
+   export npe_node_max=28
+elif [[ "$machine" = "WCOSS_C" ]]; then
+   export npe_node_max=24
+elif [[ "$machine" = "THEIA" ]]; then
+   export npe_node_max=24
+elif [[ "$machine" = "JET" ]]; then
+   export npe_node_max=24
+elif [[ "$machine" = "HERA" ]]; then
+   export npe_node_max=40
+fi
+
+
+# (Standard) Model resolution dependent variables
+case $case_in in
+    "C48")
+        export DELTIM=450
+        export layout_x=2
+        export layout_y=4
+        export layout_x_gfs=2
+        export layout_y_gfs=4
+        export npe_wav=14
+        export npe_wav_gfs=14
+        export nth_fv3=1
+        export cdmbgwd="0.071,2.1,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
+        export WRITE_GROUP=1
+        export WRTTASK_PER_GROUP=$npe_node_max
+        export WRITE_GROUP_GFS=1
+        export WRTTASK_PER_GROUP_GFS=$npe_node_max
+        export WRTIOBUF="4M"
+        ;;
+    "C96")
+        export DELTIM=450
+        export layout_x=4
+        export layout_y=4
+        export layout_x_gfs=4
+        export layout_y_gfs=4
+        export npe_wav=14
+        export npe_wav_gfs=14
+        export nth_fv3=1
+        export cdmbgwd="0.14,1.8,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
+        export WRITE_GROUP=1
+        export WRTTASK_PER_GROUP=$npe_node_max
+        export WRITE_GROUP_GFS=1
+        export WRTTASK_PER_GROUP_GFS=$npe_node_max
+        export WRTIOBUF="4M"
+        ;;
+    "C192")
+        export DELTIM=450
+        export layout_x=4
+        export layout_y=6
+        export layout_x_gfs=4
+        export layout_y_gfs=6
+        export npe_wav=21
+        export npe_wav_gfs=21
+        export nth_fv3=2
+        export cdmbgwd="0.23,1.5,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
+        export WRITE_GROUP=1
+        export WRTTASK_PER_GROUP=$npe_node_max
+        export WRITE_GROUP_GFS=2
+        export WRTTASK_PER_GROUP_GFS=$npe_node_max
+        export WRTIOBUF="8M"
+        ;;
+    "C384")
+        export DELTIM=240
+        export layout_x=8
+        export layout_y=8
+        export layout_x_gfs=6
+        export layout_y_gfs=6
+        export npe_wav=35  
+        export npe_wav_gfs=35  
+        export nth_fv3=1
+        export cdmbgwd="1.1,0.72,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
+        export WRITE_GROUP=1
+        export WRTTASK_PER_GROUP=$npe_node_max
+        export WRITE_GROUP_GFS=2
+        export WRTTASK_PER_GROUP_GFS=$npe_node_max
+        export WRTIOBUF="16M"
+        ;;
+    "C768")
+        if [[ "$CCPP_SUITE" == "FV3_GSD_v0" || "$CCPP_SUITE" == "FV3_GSD_noah" ]] ; then
+          if [ $LEVS = "128" ]; then
+            export DELTIM=100
+          else
+            export DELTIM=225
+          fi
+        else
+          export DELTIM=150
+        fi
+        export layout_x=12
+        export layout_y=8
+        export layout_x_gfs=16
+        export layout_y_gfs=12
+        export npe_wav=70  
+        export npe_wav_gfs=70  
+        export nth_fv3=4
+        export cdmbgwd="4.0,0.15,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
+        export WRITE_GROUP=2
+        export WRTTASK_PER_GROUP=$(echo "2*$npe_node_max" |bc)
+        export WRITE_GROUP_GFS=4
+        export WRTTASK_PER_GROUP_GFS=$(echo "2*$npe_node_max" |bc)
+        export WRTIOBUF="32M"
+        ;;
+    "C1152")
+        export DELTIM=120
+        export layout_x=8
+        export layout_y=16
+        export layout_x_gfs=8
+        export layout_y_gfs=16
+        export npe_wav=140
+        export npe_wav_gfs=140
+        export nth_fv3=4
+        export cdmbgwd="4.0,0.10,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
+        export WRITE_GROUP=4
+        export WRTTASK_PER_GROUP=$(echo "2*$npe_node_max" |bc)
+        export WRITE_GROUP_GFS=4
+        export WRTTASK_PER_GROUP_GFS=$(echo "2*$npe_node_max" |bc)
+        export WRTIOBUF="48M"
+        ;;
+    "C3072")
+        export DELTIM=90
+        export layout_x=16
+        export layout_y=32
+        export layout_x_gfs=16
+        export layout_y_gfs=32
+        export npe_wav=140
+        export npe_wav_gfs=140
+        export nth_fv3=4
+        export cdmbgwd="4.0,0.05,1.0,1.0"  # mountain blocking, ogwd, cgwd, cgwd src scaling
+        export WRITE_GROUP=4
+        export WRTTASK_PER_GROUP=$(echo "3*$npe_node_max" |bc)
+        export WRITE_GROUP_GFS=4
+        export WRTTASK_PER_GROUP_GFS=$(echo "3*$npe_node_max" |bc)
+        export WRTIOBUF="64M"
+        ;;
+    *)
+        echo "grid $case_in not supported, ABORT!"
+        exit 1
+        ;;
+esac
+
+echo "END: config.fv3"

--- a/FV3GFSwfm/rt_ccpp_c384/config.fv3ic
+++ b/FV3GFSwfm/rt_ccpp_c384/config.fv3ic
@@ -1,0 +1,19 @@
+#!/bin/ksh -x
+
+########## config.fv3ic ##########
+# Convert GFS initial conditions into FV3 initial conditions
+
+echo "BEGIN: config.fv3ic"
+
+# Task and thread configuration
+export wtime_fv3ic="00:30:00"
+export npe_fv3ic=1
+export npe_node_fv3ic=1
+export nth_fv3ic=${NTHREADS_CHGRES:-24}
+if [ $machine = HERA ]; then
+  export npe_fv3ic=4
+  export npe_node_fv3ic=4
+  export nth_fv3ic=1
+fi 
+
+echo "END: config.fv3ic"

--- a/FV3GFSwfm/rt_ccpp_c384/config.gempak
+++ b/FV3GFSwfm/rt_ccpp_c384/config.gempak
@@ -1,0 +1,13 @@
+#!/bin/ksh -x
+
+########## config.gempak ##########
+# GFS gempak step specific
+
+echo "BEGIN: config.gempak"
+
+# Get task specific resources
+. $EXPDIR/config.resources gempak
+
+export GEMPAKSH=$HOMEgfs/jobs/JGFS_GEMPAK
+
+echo "END: config.gempak"

--- a/FV3GFSwfm/rt_ccpp_c384/config.getic
+++ b/FV3GFSwfm/rt_ccpp_c384/config.getic
@@ -1,0 +1,20 @@
+#!/bin/ksh -x
+
+########## config.getic ##########
+# Fetching GFS initial conditions specific
+
+echo "BEGIN: config.getic"
+
+# Get task specific resources
+. $EXPDIR/config.resources getic
+
+# We should just be supporting the OPSGFS only
+export ics_from="opsgfs" # initial conditions from opsgfs or pargfs
+
+# Provide a parallel experiment name and path to HPSS archive
+if [ $ics_from = "pargfs" ]; then
+    export parexp="prnemsrn"
+    export HPSS_PAR_PATH="/5year/NCEPDEV/emc-global/emc.glopara/WCOSS_C/$parexp"
+fi
+
+echo "END: config.getic"

--- a/FV3GFSwfm/rt_ccpp_c384/config.gldas
+++ b/FV3GFSwfm/rt_ccpp_c384/config.gldas
@@ -1,0 +1,16 @@
+#!/bin/ksh -x
+
+########## config.gldas ##########
+# GDAS gldas step specific
+
+echo "BEGIN: config.gldas"
+
+# Get task specific resources
+. $EXPDIR/config.resources gldas
+
+export GLDASSH=$HOMEgfs/scripts/exgdas_gldas.sh.ecf
+export gldas_spinup_hours=72
+export CPCGAUGE=$DMPDIR
+
+
+echo "END: config.gldas"

--- a/FV3GFSwfm/rt_ccpp_c384/config.metp
+++ b/FV3GFSwfm/rt_ccpp_c384/config.metp
@@ -1,0 +1,69 @@
+#!/bin/ksh -x
+
+########## config.metp ##########
+# METplus verification step specific
+
+echo "BEGIN: config.metp"
+
+# Get task specific resources
+. $EXPDIR/config.resources metp
+
+export RUN_GRID2GRID_STEP1="YES" # Run grid-to-grid verification using METplus
+export RUN_GRID2OBS_STEP1="YES"  # Run grid-to-obs verification using METplus
+export RUN_PRECIP_STEP1="YES"    # Run precip verification using METplus
+
+
+#----------------------------------------------------------
+# METplus, Verify grid-to-grid, and/or grid-to-obs, and/or precipitation options
+#----------------------------------------------------------
+
+if [ "$CDUMP" = "gfs" ] ; then
+    if [ $RUN_GRID2GRID_STEP1 = "YES" -o $RUN_GRID2OBS_STEP1 = "YES" -o $RUN_PRECIP_STEP1 = "YES" ]; then
+        export HOMEverif_global=${HOMEgfs}/sorc/verif-global.fd
+        export VERIF_GLOBALSH=$HOMEverif_global/ush/run_verif_global_in_global_workflow.sh
+        ## INPUT DATA SETTINGS
+        export model_list=$PSLOT
+        export model_data_dir_list=$ARCDIR/..
+        export model_fileformat_list="pgbf{lead?fmt=%H}.${CDUMP}.{init?fmt=%Y%m%d%H}.grib2"
+        export model_hpssdir_list=$ATARDIR/.. 
+        export get_data_from_hpss="NO"
+        export hpss_walltime="10"
+        ## OUTPUT SETTINGS
+        export OUTPUTROOT=$RUNDIR/$CDUMP/$CDATE/vrfy/metplus_exp
+        export model_arch_dir_list=$ARCDIR/..
+        export make_met_data_by="VALID"
+        export gather_by="VSDB"
+        ## DATE SETTINGS
+        export VRFYBACK_HRS="24"
+        ## METPLUS SETTINGS
+        export METplus_verbosity="INFO"
+        export MET_verbosity="2"
+        export log_MET_output_to_METplus="yes"
+        ## FORECAST VERIFICATION SETTINGS
+        export fhr_min=$FHMIN_GFS
+        export fhr_max=$FHMAX_GFS
+        # GRID-TO-GRID STEP 1
+        export g2g1_type_list="anom pres sfc"
+        export g2g1_anl_name="self_anl"
+        export g2g1_anl_fileformat_list="pgbanl.gfs.{valid?fmt=%Y%m%d%H}.grib2"
+        export g2g1_grid="G002"
+        # GRID-TO-OBS STEP 1
+        export g2o1_type_list="upper_air conus_sfc"
+        export g2o1_obtype_upper_air="ADPUPA"
+        export g2o1_grid_upper_air="G003"
+        export g2o1_fhr_out_upper_air="6"
+        export g2o1_obtype_conus_sfc="ONLYSF ADPUPA"
+        export g2o1_grid_conus_sfc="G104"
+        export g2o1_fhr_out_conus_sfc="3"
+        export g2o1_prepbufr_data_runhpss="YES"
+        # PRECIP STEP 1
+        export precip1_obtype="ccpa"
+        export precip1_accum_length="24"
+        export precip1_model_bucket_list="06"
+        export precip1_model_varname_list="APCP"
+        export precip1_model_fileformat_list="pgbf{lead?fmt=%H}.gfs.{init?fmt=%Y%m%d%H}.grib2"
+        export precip1_grid="G211"
+    fi
+fi
+
+echo "END: config.metp"

--- a/FV3GFSwfm/rt_ccpp_c384/config.nsst
+++ b/FV3GFSwfm/rt_ccpp_c384/config.nsst
@@ -1,0 +1,45 @@
+#!/bin/ksh -x
+
+########## config.nsst ##########
+# NSST specific
+
+echo "BEGIN: config.nsst"
+
+# NSST parameters contained within nstf_name
+
+# nstf_name(1) : NST_MODEL (NSST Model) : 0 = OFF, 1 = ON but uncoupled, 2 = ON and coupled
+export NST_MODEL=2
+
+# nstf_name(2) : NST_SPINUP : 0 = OFF, 1 = ON,
+if [[ "$CCPP_SUITE" == "FV3_GSD_v0" || "$CCPP_SUITE" == "FV3_GSD_noah" ]] ; then
+  export NST_SPINUP=1
+else 
+  export NST_SPINUP=0
+fi
+#if [[ "$CDATE" = $SDATE ]]; then
+#    export NST_SPINUP=1
+#fi
+
+# nstf_name(3) : NST_RESV (Reserved, NSST Analysis) : 0 = OFF, 1 = ON
+if [[ "$CCPP_SUITE" == "FV3_GSD_v0" || "$CCPP_SUITE" == "FV3_GSD_noah" ]] ; then
+  export NST_RESV=1
+else
+  export NST_RESV=0
+fi
+
+# nstf_name(4,5) : ZSEA1, ZSEA2 the two depths to apply vertical average (bias correction)
+export ZSEA1=0
+if [[ "$CCPP_SUITE" == "FV3_GSD_v0" || "$CCPP_SUITE" == "FV3_GSD_noah" ]] ; then
+  export ZSEA2=5
+else
+  export ZSEA2=0
+fi
+
+export NST_GSI=3          # default 0: No NST info at all;
+                          #         1: Input NST info but not used in GSI;
+                          #         2: Input NST info, used in CRTM simulation, no Tr analysis
+                          #         3: Input NST info, used in both CRTM simulation and Tr analysis
+export NSTINFO=0          # number of elements added in obs. data array (default = 0)
+if [ $NST_GSI -gt 0 ]; then export NSTINFO=4; fi
+
+echo "END: config.nsst"

--- a/FV3GFSwfm/rt_ccpp_c384/config.post
+++ b/FV3GFSwfm/rt_ccpp_c384/config.post
@@ -1,0 +1,56 @@
+#!/bin/ksh -x
+
+########## config.post ##########
+# Post specific
+
+echo "BEGIN: config.post"
+
+# Get task specific resources
+. $EXPDIR/config.resources post
+
+# Convert nemsio files to grib files using post job
+#-------------------------------------------
+
+# No. of concurrent post jobs [0 implies sequential]
+export NPOSTGRP=42
+export OUTTYP=4
+export MODEL_OUT_FORM=binarynemsiompiio
+if [ $OUTPUT_FILE = "netcdf" ]; then 
+    export MODEL_OUT_FORM=netcdfpara
+fi
+
+# Post driver job that calls gfs_nceppost.sh and downstream jobs
+export POSTJJOBSH="$HOMEpost/jobs/JGLOBAL_NCEPPOST"
+export GFSDOWNSH="$HOMEpost/ush/fv3gfs_downstream_nems.sh"
+export GFSDWNSH="$HOMEpost/ush/fv3gfs_dwn_nems.sh"
+
+export POSTGPSH="$HOMEpost/ush/gfs_nceppost.sh"
+export POSTGPEXEC="$HOMEpost/exec/gfs_ncep_post"
+#export GOESF=YES                              # goes image
+export GOESF=NO                              # goes image
+export WAFSF=NO                               # WAFS products
+#export FLXF=YES                               # grib2 flux file written by post
+export FLXF=NO                               # grib2 flux file written by post
+#export PGB1F=YES                              
+export PGB1F=NO                              
+if [ $RUN_ENVIR = "nco" ]; then
+    export PGB1F=NO
+    export GTGF=YES
+fi
+
+export npe_postgp=$npe_post
+export nth_postgp=1
+
+export GFS_DOWNSTREAM="YES"
+#export downset=2
+export downset=1
+if [ $machine = "WCOSS_DELL_P3" ]; then
+    export npe_dwn=28
+else
+    export npe_dwn=24
+fi
+
+export GRIBVERSION='grib2'
+export SENDCOM="YES"
+
+echo "END: config.post"

--- a/FV3GFSwfm/rt_ccpp_c384/config.postsnd
+++ b/FV3GFSwfm/rt_ccpp_c384/config.postsnd
@@ -1,0 +1,13 @@
+#!/bin/ksh -x
+
+########## config.postsnd ##########
+# GFS bufr sounding step specific
+
+echo "BEGIN: config.postsnd"
+
+# Get task specific resources
+. $EXPDIR/config.resources postsnd
+
+export POSTSNDSH=$HOMEgfs/jobs/JGFS_POSTSND
+
+echo "END: config.postsnd"

--- a/FV3GFSwfm/rt_ccpp_c384/config.prep
+++ b/FV3GFSwfm/rt_ccpp_c384/config.prep
@@ -1,0 +1,55 @@
+#!/bin/ksh -x
+
+########## config.prep ##########
+# Prep step specific
+
+echo "BEGIN: config.prep"
+
+# Get task specific resources
+. $EXPDIR/config.resources prep
+
+export DO_MAKEPREPBUFR="YES"   # if NO, will copy prepbufr from globaldump
+
+
+# Relocation and syndata QC
+export PROCESS_TROPCY=${PROCESS_TROPCY:-NO}
+[[ $RUN_ENVIR == "nco" && $envir == "prod" ]] && export PROCESS_TROPCY="YES"
+export DO_RELOCATE="NO"
+export TROPCYQCRELOSH="$HOMEgfs/scripts/extropcy_qc_reloc.sh.ecf"
+export SENDCOM=YES
+
+export HOMERELO=$HOMEgfs
+export EXECRELO=${HOMERELO}/exec
+export FIXRELO=${HOMERELO}/fix/fix_am
+export USHRELO=${HOMERELO}/ush
+
+
+# Adjust observation error for GFS v16 parallels
+#
+#   NOTE:  Remember to set OBERROR in config.anal as PRVT is set below
+#
+# Set default prepobs_errtable.global
+export PRVT=$FIXgsi/prepobs_errtable.global
+
+
+# Set prepobs.errtable.global for start of GFS v16 parallels
+if [[ "$CDATE" -ge "2019021900" && "$CDATE" -lt "2019110706" ]]; then
+    export PRVT=$FIXgsi/gfsv16_historical/prepobs_errtable.global.2019021900
+fi
+
+# Place GOES-15 AMVs in monitor, assimilate GOES-17 AMVs, assimilate KOMPSAT-5 gps
+  if [[ "$CDATE" -ge "2019110706" && "$CDATE" -lt "2020040718" ]]; then
+     export PRVT=$FIXgsi/gfsv16_historical/prepobs_errtable.global.2019110706
+  fi
+
+#NOTE:
+#   As of 2020040718, gfsv16_historical/prepobs_errtable.global.2020040718 is
+#   identical to ../prepobs_errtable.global.  Thus, the logic below is not
+#   needed at this time
+
+# Set observation errors for type 135 (T) & 235 (uv) Canadian AMDAR observations
+##if [[ "$CDATE" -ge "2020040718" && "$CDATE" -lt "YYYMMDDHH" ]]; then
+##    export PRVT=$EXPDIR/prepobs_errtable.global
+##fi
+
+echo "END: config.prep"

--- a/FV3GFSwfm/rt_ccpp_c384/config.prepbufr
+++ b/FV3GFSwfm/rt_ccpp_c384/config.prepbufr
@@ -1,0 +1,17 @@
+#!/bin/ksh -x
+
+########## config.prepbufr ##########
+# PREPBUFR specific configuration
+
+echo "BEGIN: config.prepbufr"
+
+# Get task specific resources
+. $EXPDIR/config.resources prepbufr
+
+# Set variables
+
+if [ $machine = "HERA" ]; then
+    export GESROOT=/scratch1/NCEPDEV/rstprod   # set by module prod_envir on WCOSS_C
+fi
+
+echo "END: config.prepbufr"

--- a/FV3GFSwfm/rt_ccpp_c384/config.prepchem
+++ b/FV3GFSwfm/rt_ccpp_c384/config.prepchem
@@ -1,0 +1,18 @@
+#!/bin/ksh -x
+
+########## config.prepchem ##########
+# PREPBUFR specific configuration
+
+echo "BEGIN: config.prepchem"
+
+# Get task specific resources
+. $EXPDIR/config.resources prepchem
+
+
+# Set prepchem variables 
+
+# Set job and DATAROOT
+export job=${CDUMP}_prep_${cyc}
+export EMIDIR="/scratch1/BMC/gsd-fv3-dev/lzhang/emi_"
+#export EMIINPUT=/scratch1/BMC/gsd-fv3-dev/Haiqin.Li/Develop/emi_C"
+echo "END: config.prepchem"

--- a/FV3GFSwfm/rt_ccpp_c384/config.regrid
+++ b/FV3GFSwfm/rt_ccpp_c384/config.regrid
@@ -1,0 +1,18 @@
+#!/bin/ksh -x
+
+########## config.regrid ##########
+# REGRID specific configuration
+
+echo "BEGIN: config.regrid"
+
+# Get task specific resources
+. $EXPDIR/config.resources regrid
+
+
+# Set regrid variables 
+
+# Set job and DATAROOT
+export job=${CDUMP}_regrid_${cyc}
+export DATA="$RUNDIR/$CDATE/$CDUMP"
+export INPUTDIR="/scratch1/BMC/gfs-fv3-dev/lzhang/EMC_FV3/ICs"
+echo "END: config.regrid"

--- a/FV3GFSwfm/rt_ccpp_c384/config.resources
+++ b/FV3GFSwfm/rt_ccpp_c384/config.resources
@@ -1,0 +1,382 @@
+#!/bin/ksh -x
+
+########## config.resources ##########
+# Set resource information for job tasks
+# e.g. walltime, node, cores per node, memory etc.
+
+if [ $# -ne 1 ]; then
+
+    echo "Must specify an input task argument to set resource variables!"
+    echo "argument can be any one of the following:"
+    echo "anal analcalc analdiag gldas fcst post vrfy metp arch echgres"
+    echo "eobs ediag eomg eupd ecen esfc efcs epos earc"
+    echo "waveinit waveprep wavepostsbs wavegempaksbs waveawipssbs"
+    echo "wavepost waveawips wavestat"
+    echo "postsnd awips gempak"
+    exit 1
+
+fi
+
+step=$1
+
+echo "BEGIN: config.resources"
+
+if [[ "$machine" = "WCOSS_DELL_P3" ]]; then
+   export npe_node_max=28
+   if [ "$QUEUE" = "dev2" -o "$QUEUE" = "devonprod2" -o "$QUEUE" = "devmax2" ]; then # WCOSS Dell 3.5
+     export npe_node_max=40
+   fi
+elif [[ "$machine" = "WCOSS_C" ]]; then
+   export npe_node_max=24
+elif [[ "$machine" = "JET" ]]; then
+   export npe_node_max=24
+elif [[ "$machine" = "HERA" ]]; then
+   export npe_node_max=40
+fi
+
+if [ $step = "prep" -o $step = "prepbufr" ]; then
+
+    eval "export wtime_$step='00:45:00'"
+    eval "export npe_$step=4"
+    eval "export npe_node_$step=4"
+    eval "export nth_$step=1"
+
+elif [ $step = "waveinit" ]; then
+
+    export wtime_waveinit="00:10:00"
+    export npe_waveinit=10
+    export nth_waveinit=1
+    export npe_node_waveinit=$(echo "$npe_node_max / $nth_waveinit" | bc)
+    export NTASKS=${npe_waveinit}
+
+elif [ $step = "waveprep" ]; then
+
+    export wtime_waveprep="00:30:00"
+    export npe_waveprep=115
+    export nth_waveprep=1
+    export npe_node_waveprep=$(echo "$npe_node_max / $nth_waveprep" | bc)
+    export NTASKS=${npe_waveprep}
+
+elif [ $step = "wavepostsbs" ]; then
+
+    export wtime_wavepostsbs="06:00:00"
+    export npe_wavepostsbs=280
+    export nth_wavepostsbs=1
+    export npe_node_wavepostsbs=$(echo "$npe_node_max / $nth_wavepostsbs" | bc)
+    export NTASKS=${npe_wavepostsbs}
+
+elif [ $step = "wavegempaksbs" ]; then
+
+    export wtime_wavegempaksbs="06:00:00"
+    export npe_wavegempaksbs=$npe_node_max
+    export nth_wavegempaksbs=1
+    export npe_node_wavegempaksbs=$(echo "$npe_node_max / $nth_wavegempaksbs" | bc)
+    export NTASKS=${npe_wavegempaksbs}
+
+elif [ $step = "waveawipssbs" ]; then
+
+    export wtime_waveawipssbs="08:00:00"
+    export npe_waveawipssbs=$npe_node_max
+    export nth_waveawipssbs=1
+    export npe_node_waveawipssbs=$(echo "$npe_node_max / $nth_waveawipssbs" | bc)
+    export NTASKS=${npe_waveawipssbs}
+
+elif [ $step = "wavepost" ]; then
+
+    export wtime_wavepost="01:00:00"
+    export npe_wavepost=560
+    export nth_wavepost=1
+    export npe_node_wavepost=$(echo "$npe_node_max / $nth_wavepost" | bc)
+    export NTASKS=${npe_wavepost}
+
+elif [ $step = "waveawips" ]; then
+
+    export wtime_waveawips="06:00:00"
+    export npe_waveawips=$npe_node_max
+    export nth_waveawips=1
+    export npe_node_waveawips=$(echo "$npe_node_max / $nth_waveawips" | bc)
+    export NTASKS=${npe_waveawips}
+
+elif [ $step = "wavestat" ]; then
+
+    export wtime_wavestat="01:00:00"
+    export npe_wavestat=$npe_node_max
+    export nth_wavestat=1
+    export npe_node_wavestat=$(echo "$npe_node_max / $nth_wavestat" | bc)
+    export NTASKS=${npe_wavestats}
+
+elif [ $step = "anal" ]; then
+
+    export wtime_anal="02:00:00"
+    export npe_anal=800
+    export nth_anal=4  
+    if [ $CASE = "C384" ]; then
+      export npe_anal=160
+      export nth_anal=10
+    fi
+    if [ $CASE = "C192" -o $CASE = "C96" -o $CASE = "C48" ]; then export npe_anal=84; fi
+    if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export nth_anal=7; fi
+    export npe_node_anal=$(echo "$npe_node_max / $nth_anal" | bc)
+    export nth_cycle=$npe_node_max
+    if [[ "$machine" == "WCOSS_C" ]]; then export memory_anal="3072M"; fi
+
+elif [ $step = "analcalc" ]; then
+
+    export wtime_analcalc="02:00:00"
+    export npe_analcalc=127
+    export nth_analcalc=1
+    export npe_node_analcalc=$npe_node_max
+    if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export npe_analcalc=127 ; fi
+    if [[ "$machine" == "WCOSS_C" ]]; then export memory_analcalc="3072M"; fi
+
+elif [ $step = "analdiag" ]; then
+
+    export wtime_analdiag="02:00:00"
+    export npe_analdiag=112
+    export nth_analdiag=1
+    export npe_node_analdiag=$npe_node_max
+    if [[ "$machine" == "WCOSS_C" ]]; then export memory_analdiag="3072M"; fi
+
+elif [ $step = "gldas" ]; then
+
+    export wtime_gldas="02:00:00"
+    export npe_gldas=96  
+    export nth_gldas=1 
+    export npe_node_gldas=$npe_node_max
+    export npe_gaussian=96  
+    export nth_gaussian=1 
+    export npe_node_gaussian=24           
+    if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export npe_gldas=112 ; fi
+    if [[ "$machine" == "WCOSS_C" ]]; then export memory_gldas="3072M"; fi
+
+elif [ $step = "checkgdas" ]; then
+
+    export wtime_checkgdas="00:10:00"
+    export npe_checkgdas=1
+    export npe_node_checkgdas=1
+elif [ $step = "gfsgetic" ]; then
+
+    export wtime_getic="00:15:00"
+    export npe_getic=1
+    export npe_node_getic=1
+
+elif [ $step = "regrid" ]; then
+
+    export wtime_regrid="00:15:00"
+    export npe_regrid=2
+    export npe_node_regrid=1
+
+elif [ $step = "calcinc" ]; then
+
+    export wtime_calcinc="00:15:00"
+    export npe_calcinc=2
+    export npe_node_calcinc=1
+
+elif [ $step = "prepchem" ]; then
+
+    export wtime_prepchem="00:15:00"
+    export npe_prepchem=2
+    export npe_node_prepchem=1
+
+elif [ $step = "fcst" ]; then
+
+    export wtime_fcst="01:00:00"
+    export wtime_fcst_gfs="08:00:00"
+    export npe_fcst=$(echo "$layout_x * $layout_y * 6" | bc)
+    export npe_fcst_gfs=$(echo "$layout_x_gfs * $layout_y_gfs * 6" | bc)
+    export nth_fcst=${nth_fv3:-2}
+    export npe_node_fcst=$(echo "$npe_node_max / $nth_fcst" | bc)
+    if [[ "$machine" == "WCOSS_C" ]]; then export memory_fcst="1024M"; fi
+
+elif [ $step = "post" ]; then
+
+    export wtime_post="02:00:00"
+    export wtime_post_gfs="06:00:00"
+    export npe_post=48 
+    export nth_post=1
+    export npe_node_post=12
+    export npe_node_dwn=$npe_node_max
+    if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export npe_node_post=14 ; fi
+    if [[ "$machine" == "WCOSS_C" ]]; then export memory_post="3072M"; fi
+
+elif [ $step = "vrfy" ]; then
+
+    export wtime_vrfy="03:00:00"
+    export wtime_vrfy_gfs="06:00:00"
+    export npe_vrfy=3
+    export nth_vrfy=1
+    export npe_node_vrfy=1
+    export npe_vrfy_gfs=1
+    export npe_node_vrfy_gfs=1
+    if [[ "$machine" == "WCOSS_C" ]]; then
+	    export memory_vrfy="3072M"
+    elif [[ "$machine" == "HERA" ]]; then
+	    export memory_vrfy="16384M"
+    fi
+
+elif [ $step = "metp" ]; then
+    
+    export nth_metp=1
+    export wtime_metp="03:00:00"
+    export npe_metp=4
+    export npe_node_metp=4
+    export wtime_metp_gfs="06:00:00"
+    export npe_metp_gfs=4
+    export npe_node_metp_gfs=4
+    if [[ "$machine" == "WCOSS_C" ]]; then
+            export memory_metp="3072M"
+    elif [[ "$machine" == "THEIA" ]]; then
+            export memory_metp="16384M"
+    fi
+
+elif [ $step = "echgres" ]; then
+
+    export wtime_echgres="01:00:00"
+    export npe_echgres=3
+    export nth_echgres=$npe_node_max
+    export npe_node_echgres=1
+
+elif [ $step = "arch" -o $step = "earc" -o $step = "getic" ]; then
+
+    eval "export wtime_$step='06:00:00'"
+    eval "export npe_$step=1"
+    eval "export npe_node_$step=1"
+    eval "export nth_$step=1"
+    eval "export memory_$step=2048M"
+
+elif [ $step = "eobs" -o $step = "eomg" ]; then
+
+
+    export wtime_eobs="00:30:00"
+    export wtime_eomg="01:00:00"
+    if [ $CASE = "C768" ]; then
+      export npe_eobs=100
+    elif [ $CASE = "C384" ]; then
+      export npe_eobs=42
+    elif [ $CASE = "C192" ]; then
+      export npe_eobs=28
+    elif [ $CASE = "C96" -o $CASE = "C48" ]; then
+      export npe_eobs=14
+    fi
+    export nth_eobs=2
+    if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export nth_eobs=7; fi
+    export npe_node_eobs=$(echo "$npe_node_max / $nth_eobs" | bc)
+    if [[ "$machine" == "WCOSS_C" ]]; then export memory_eobs="3072M"; fi
+
+elif [ $step = "ediag" ]; then
+
+    export wtime_ediag="02:00:00"
+    export npe_ediag=56
+    export nth_ediag=1
+    export npe_node_ediag=$npe_node_max
+    if [[ "$machine" == "WCOSS_C" ]]; then export memory_ediag="3072M"; fi
+
+elif [ $step = "eupd" ]; then
+
+    export wtime_eupd="01:30:00"
+    if [ $CASE = "C768" ]; then
+      export npe_eupd=540
+      export nth_eupd=6
+      if [[ "$machine" = "WCOSS_DELL_P3" ]]; then
+        export nth_eupd=9
+      fi
+    elif [ $CASE = "C384" ]; then
+      export npe_eupd=270
+      export nth_eupd=2
+      if [[ "$machine" = "WCOSS_DELL_P3" ]]; then
+        export nth_eupd=9
+      fi
+      if [[ "$machine" = "HERA" ]]; then
+        export npe_eupd=84
+        export nth_eupd=10
+      fi
+    elif [ $CASE = "C192" -o $CASE = "C96" -o $CASE = "C48" ]; then
+      export npe_eupd=42
+      export nth_eupd=2
+    fi
+    export npe_node_eupd=$(echo "$npe_node_max / $nth_eupd" | bc)
+    if [[ "$machine" == "WCOSS_C" ]]; then
+        export memory_eupd="3072M"
+    fi
+
+elif [ $step = "ecen" ]; then
+
+    export wtime_ecen="00:30:00"
+    export npe_ecen=80
+    export nth_ecen=6
+    if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export nth_ecen=7; fi
+    if [ $CASE = "C384" -o $CASE = "C192" -o $CASE = "C96" -o $CASE = "C48" ]; then export nth_ecen=2; fi
+    export npe_node_ecen=$(echo "$npe_node_max / $nth_ecen" | bc)
+    export nth_cycle=$nth_ecen
+    if [[ "$machine" == "WCOSS_C" ]]; then export memory_ecen="3072M"; fi
+
+elif [ $step = "esfc" ]; then
+
+    export wtime_esfc="03:00:00"
+    export npe_esfc=80
+    export npe_node_esfc=$npe_node_max
+    export nth_esfc=1
+    export nth_cycle=$nth_esfc
+    if [[ "$machine" == "WCOSS_C" ]]; then export memory_esfc="3072M"; fi
+
+elif [ $step = "efcs" ]; then
+
+    export wtime_efcs="03:00:00"
+    export npe_efcs=$(echo "$layout_x * $layout_y * 6" | bc)
+    export nth_efcs=${nth_fv3:-2}
+    export npe_node_efcs=$(echo "$npe_node_max / $nth_efcs" | bc)
+    if [[ "$machine" == "WCOSS_C" ]]; then export memory_efcs="254M"; fi
+
+elif [ $step = "epos" ]; then
+
+    export wtime_epos="03:00:00"
+    export npe_epos=80
+    export nth_epos=6
+    if [[ "$machine" = "WCOSS_DELL_P3" ]]; then export nth_epos=7; fi
+    export npe_node_epos=$(echo "$npe_node_max / $nth_epos" | bc)
+    if [[ "$machine" == "WCOSS_C" ]]; then export memory_epos="254M"; fi
+
+elif [ $step = "postsnd" ]; then
+
+    export wtime_postsnd="02:00:00"
+    export npe_postsnd=40
+    export nth_postsnd=1
+    export npe_node_postsnd=4
+    export npe_postsndcfp=9
+    export npe_node_postsndcfp=3
+    if [ $OUTPUT_FILE == "nemsio" ]; then
+        export npe_postsnd=13
+        export npe_node_postsnd=4
+    fi
+    if [[ "$machine" = "HERA" ]]; then export npe_node_postsnd=2; fi
+    if [[ "$machine" == "WCOSS_C" ]]; then export memory_postsnd="254M"; fi
+
+elif [ $step = "awips" ]; then
+
+    export wtime_awips="03:30:00"
+    export npe_awips=4
+    export npe_node_awips=4
+    export nth_awips=2
+    if [[ "$machine" == "WCOSS_DELL_P3" ]]; then
+        export npe_awips=2
+        export npe_node_awips=2
+        export nth_awips=1
+    fi
+    if [[ "$machine" == "WCOSS_C" ]]; then export memory_awips="2048M"; fi
+
+elif [ $step = "gempak" ]; then
+
+    export wtime_gempak="02:00:00"
+    export npe_gempak=17
+    export npe_node_gempak=4
+    export nth_gempak=3
+    if [[ "$machine" == "WCOSS_C" ]]; then export memory_gempak="254M"; fi
+
+else
+
+    echo "Invalid step = $step, ABORT!"
+    exit 2
+
+fi
+
+echo "END: config.resources"

--- a/FV3GFSwfm/rt_ccpp_c384/config.vrfy
+++ b/FV3GFSwfm/rt_ccpp_c384/config.vrfy
@@ -1,0 +1,193 @@
+#!/bin/ksh -x
+
+########## config.vrfy ##########
+# Verification step specific
+
+echo "BEGIN: config.vrfy"
+
+# Get task specific resources
+. $EXPDIR/config.resources vrfy
+
+export VDUMP="gfs"                # Verifying dump
+export CDUMPFCST="gdas"           # Fit-to-obs with GDAS/GFS prepbufr
+export CDFNL="gdas"               # Scores verification against GDAS/GFS analysis
+
+export MKPGB4PRCP="YES"           # Make 0.25-deg pgb files in ARCDIR for precip verification
+export VRFYFITS="YES"             # Fit to observations
+export VSDB_STEP1="YES"           # Populate VSDB database
+export VSDB_STEP2="NO"
+export VRFYG2OBS="YES"            # Grid to observations, see note below if turning ON
+export VRFYPRCP="YES"             # Precip threat scores
+export VRFYRAD="YES"              # Radiance data assimilation monitoring
+export VRFYOZN="YES"              # Ozone data assimilation monitoring
+export VRFYMINMON="YES"           # GSI minimization monitoring
+export VRFYTRAK="YES"             # Hurricane track verification
+export VRFYGENESIS="YES"          # Cyclone genesis verification
+export VRFYFSU="NO"               # Cyclone genesis verification (FSU)
+export RUNMOS="NO"                # whether to run entire MOS package
+
+#-------------------------------------------------
+# Fit to Observations
+#-------------------------------------------------
+
+if [ $VRFYFITS = "YES" ]; then
+
+    export PRVT=$HOMEgfs/fix/fix_gsi/prepobs_errtable.global
+    export HYBLEVS=$HOMEgfs/fix/fix_am/global_hyblev.l${LEVS}.txt
+    export CUE2RUN=$QUEUE
+
+    export VBACKUP_FITS=24
+
+    export CONVNETC="NO"
+    if [ ${netcdf_diag:-".false."} = ".true." ]; then
+        export CONVNETC="YES"
+    fi
+
+    if [ $machine = "WCOSS_C" ]; then
+        export fitdir="$BASE_SVN/verif/global/parafits.fv3nems/batrun"
+        export PREPQFITSH="$fitdir/subfits_cray_nems"
+    elif [ $machine = "WCOSS_DELL_P3" ]; then
+        export fitdir="$BASE_SVN/verif/global/Fit2Obs/ncf-vqc/batrun"
+        export PREPQFITSH="$fitdir/subfits_dell_nems"
+    elif [ $machine = "HERA" ]; then
+        #export fitdir="$BASE_GIT/Fit2Obs/batrun"
+        export fitdir="$BASE_GIT/verif/global/Fit2Obs/ncf-vqc/batrun"
+        export PREPQFITSH="$fitdir/subfits_hera_slurm"
+    fi
+
+fi
+
+
+#----------------------------------------------------------
+# VSDB STEP1, Verify Precipipation and Grid To Obs options
+#----------------------------------------------------------
+# All these call $VSDBSH
+
+if [ "$CDUMP" = "gfs" ] ; then
+    ddd=`echo $CDATE |cut -c 1-8`
+    #if [ $ddd -eq 5 -o $ddd -eq 10 ]; then export VSDB_STEP2 = "YES" ;fi
+
+    if [ $VSDB_STEP1 = "YES" -o $VSDB_STEP2 = "YES" -o $VRFYPRCP = "YES" -o $VRFYG2OBS = "YES" ]; then
+        export BACKDATEVSDB=24                          # execute vsdbjob for the previous day
+        export VBACKUP_PRCP=24                          # back up for QPF verification data
+        export vsdbsave="$NOSCRUB/archive/vsdb_data"    # place to save vsdb database
+        export vsdbhome=$BASE_VERIF                     # location of global verification scripts
+        export VSDBSH="$vsdbhome/vsdbjob.sh"            # VSDB job script
+        export vlength=$FHMAX_GFS                       # verification length
+        export vhr_rain=$FHMAX_GFS                      # verification length for precip
+        export ftyplist="pgbq"                          # verif. files used for computing QPF ETS scores
+        export ptyplist="PRATE"                         # precip types in GRIB: PRATE or APCP
+        export anltype="gfs"                            # default=gfs, analysis type (gfs or gdas) for verification
+        export rain_bucket=6                            # prate in pgb files is 6-hr accumulated
+
+        export VSDB_START_DATE="$SDATE"                 # starting date for vsdb maps
+        export webhost="emcrzdm.ncep.noaa.gov"          # webhost(rzdm) computer
+        export webhostid="$USER"                        # webhost(rzdm) user name
+        export SEND2WEB="NO"                            # whether or not to send maps to webhost
+        export WEBDIR="/home/people/emc/www/htdocs/gmb/${webhostid}/vsdb/$PSLOT"
+        export mdlist="gfs $PSLOT "                     # exps (up to 10) to compare in maps
+    fi
+fi
+
+
+#----------------------------------------------------------
+# Minimization, Radiance and Ozone Monitoring
+#----------------------------------------------------------
+
+if [ $VRFYRAD = "YES" -o $VRFYMINMON = "YES" -o $VRFYOZN = "YES" ]; then
+
+    export envir="para"
+
+    # Radiance Monitoring
+    if [[ "$VRFYRAD" == "YES" && "$CDUMP" == "$CDFNL" ]] ; then
+
+        export RADMON_SUFFIX=$PSLOT
+        export TANKverf="$NOSCRUB/monitor/radmon"
+        export VRFYRADSH="$HOMEgfs/jobs/JGDAS_VERFRAD"
+
+    fi
+
+    # Minimization Monitoring
+    if [[ "$VRFYMINMON" = "YES" ]] ; then
+
+        export MINMON_SUFFIX=$PSLOT
+        export M_TANKverf="$NOSCRUB/monitor/minmon"
+        if [[ "$CDUMP" = "gdas" ]] ; then
+            export VRFYMINSH="$HOMEgfs/jobs/JGDAS_VMINMON"
+        elif [[ "$CDUMP" = "gfs" ]] ; then
+            export VRFYMINSH="$HOMEgfs/jobs/JGFS_VMINMON"
+        fi
+
+    fi
+
+    # Ozone Monitoring
+    if [[ "$VRFYOZN" == "YES" && "$CDUMP" == "$CDFNL" ]] ; then
+
+        export HOMEgfs_ozn="$HOMEgfs"
+        export OZNMON_SUFFIX=$PSLOT
+        export TANKverf_ozn="$NOSCRUB/monitor/oznmon"
+        export VRFYOZNSH="$HOMEgfs/jobs/JGDAS_VERFOZN"
+
+    fi
+
+fi
+
+
+#-------------------------------------------------
+# Cyclone genesis and cyclone track verification
+#-------------------------------------------------
+
+export ens_tracker_ver=v1.1.15.1
+if [ $machine = "WCOSS_DELL_P3" ] ; then
+    export ens_tracker_ver=v1.1.15.2
+fi
+export HOMEens_tracker=$BASE_GIT/tracker/ens_tracker.${ens_tracker_ver}
+
+
+if [ "$VRFYTRAK" = "YES" ]; then
+
+    export TRACKERSH="$HOMEgfs/jobs/JGFS_CYCLONE_TRACKER"
+    if [ "$CDUMP" = "gdas" ]; then
+        export FHOUT_CYCLONE=3            
+        export FHMAX_CYCLONE=$FHMAX
+    else
+        export FHOUT_CYCLONE=6            
+        export FHMAX_CYCLONE=$(( FHMAX_GFS<240 ? FHMAX_GFS : 240 ))
+    fi
+    if [ $machine = "HERA" ]; then
+       export COMROOTp1="/scratch1/NCEPDEV/global/glopara/com"
+       export COMINsyn=${COMINsyn:-${COMROOTp1}/gfs/prod/syndat}
+    else
+       export COMINsyn=${COMINsyn:-${COMROOT}/gfs/prod/syndat}
+    fi
+fi
+
+
+if [[ "$VRFYGENESIS" == "YES" && "$CDUMP" == "gfs" ]]; then
+
+    export GENESISSH="$HOMEgfs/jobs/JGFS_CYCLONE_GENESIS"
+fi
+
+if [[ "$VRFYFSU" == "YES" && "$CDUMP" == "gfs" ]]; then
+
+    export GENESISFSU="$HOMEgfs/jobs/JGFS_FSU_GENESIS"
+fi
+
+if [[ "$RUNMOS" == "YES" && "$CDUMP" == "gfs" ]]; then
+
+    if [ $machine = "WCOSS_C" ] ; then
+        export RUNGFSMOSSH="$HOMEgfs/scripts/run_gfsmos_master.sh.cray"
+    elif [ $machine = "WCOSS_DELL_P3" ] ; then
+        export RUNGFSMOSSH="$HOMEgfs/scripts/run_gfsmos_master.sh.dell"
+    elif [ $machine = "HERA" ] ; then
+        export RUNGFSMOSSH="$HOMEgfs/scripts/run_gfsmos_master.sh.hera"
+    else
+        echo "WARNING: MOS package is not enabled on $machine!"
+        export RUNMOS="NO"
+        export RUNGFSMOSSH=""
+    fi
+fi
+
+
+
+echo "END: config.vrfy"

--- a/FV3GFSwfm/rt_ccpp_c384/config.wave
+++ b/FV3GFSwfm/rt_ccpp_c384/config.wave
@@ -1,0 +1,124 @@
+#!/bin/ksh -x
+
+########## config.wave ##########
+# Wave steps specific
+
+echo "BEGIN: config.wave"
+
+# Parameters that are common to all wave model steps
+
+# System and version
+export wave_sys_ver=v1.0.0
+
+# This config contains variables/parameters used in the fcst step
+# Some others are also used across the workflow in wave component scripts
+
+# General runtime labels
+# export WAV_MOD_ID=${WAV_MOD_ID:-wave} # generic modID=wave valid for GFSv16 and beyond
+# COMPONENTwave stands for model component, in addition to NET/RUN for coupled systems
+export COMPONENTwave=${COMPONENTwave:-${RUN}wave}
+
+# In GFS/GDAS, restart files are generated/read from gdas runs
+# Can I use rCDUMP here????
+export COMPONENTRSTwave=${COMPONENTRSTwave:-gdaswave}
+
+# Grids for wave model
+# GFSv16
+export waveGRD='gnh_10m aoc_9km gsh_15m'
+export waveGRDN='1 2 3' # gridnumber for ww3_multi
+export waveGRDG='10 20 30' # gridgroup for ww3_multi
+
+# ESMF input grid
+export waveesmfGRD='glox_10m' # input grid
+
+# Grids for input fields
+export WAVEICE_DID=sice
+export WAVEICE_FID=glix_10m
+export WAVECUR_DID=rtofs
+export WAVECUR_FID=glix_10m
+export WAVEWND_DID=
+export WAVEWND_FID=
+
+# Grids for output fields (used in all steps)
+export waveuoutpGRD=points
+export waveinterpGRD='glo_15mxt' # Grids that need to be interpolated from native
+                             # in POST will generate grib unless gribOK not set
+export wavesbsGRD=''  # side-by-side grids generated as wave model runs, writes to com
+export wavepostGRD='gnh_10m aoc_9km gsh_15m' # Native grids that will be post-processed (grib2)
+
+# CDATE
+export CDATE=${PDY}${cyc}
+
+# The start time reflects the number of hindcast hours prior to the cycle initial time
+if [ "$CDUMP" = "gdas" ]; then
+  export FHMAX_WAV=${FHMAX:-9}
+else
+  export FHMAX_WAV=$FHMAX_GFS
+fi
+export WAVHINDH=${WAVHINDH:-0}
+export FHMIN_WAV=${FHMIN_WAV:-0}
+export FHOUT_WAV=${FHOUT_WAV:-3}
+export FHMAX_HF_WAV=${FHMAX_HF_WAV:-120}
+export FHOUT_HF_WAV=${FHOUT_HF_WAV:-1}
+
+# gridded and point output rate
+export DTFLD_WAV=`expr $FHOUT_HF_WAV \* 3600`
+export DTPNT_WAV=3600
+export FHINCP_WAV=`expr $DTPNT_WAV / 3600`
+
+# Selected output parameters (gridded)
+export OUTPARS_WAV="WND CUR ICE HS T01 T02 DIR FP DP PHS PTP PDIR CHA"
+
+# Restart file config
+if [ "$CDUMP" = "gdas" ]; then
+  WAVNCYC=4
+  WAVHCYC=6
+  FHMAX_WAV_CUR=${FHMAX_WAV_CUR:-48} # RTOFS forecasts only out to 8 days
+elif [ ${gfs_cyc} -ne 0 ]; then 
+  FHMAX_WAV_CUR=${FHMAX_WAV_CUR:-192} # RTOFS forecasts only out to 8 days
+  WAVHCYC=`expr 24 / ${gfs_cyc}`
+else
+  WAVHCYC=0
+  FHMAX_WAV_CUR=${FHMAX_WAV_CUR:-192} # RTOFS forecasts only out to 8 days
+fi
+export FHMAX_WAV_CUR WAVHCYC WAVNCYC
+
+# Restart timing business
+if [ "${CDUMP}" != gfs ]; then    # Setting is valid for GDAS and GEFS 
+  export RSTTYPE_WAV='T'          # generate second tier of restart files
+  export DT_1_RST_WAV=10800       # time between restart files, set to DTRST=1 for a single restart file
+  export DT_2_RST_WAV=43200       # restart stride for checkpointing restart
+  export RSTIOFF_WAV=0            # first restart file offset relative to model start
+else                              # This is a GFS run
+  rst_dt_gfs=$(( restart_interval_gfs * 3600 ))
+  export RSTTYPE_WAV='F'                 # generate second tier of restart files
+  if [ $rst_dt_gfs -gt 0 ]; then export RSTTYPE_WAV='T' ; fi
+  export DT_1_RST_WAV=${rst_dt_gfs:-0}   # time between restart files, set to DTRST=1 for a single restart file
+  export DT_2_RST_WAV=${rst_dt_gfs:-0}   # restart stride for checkpointing restart
+  export RSTIOFF_WAV=0                   # first restart file offset relative to model start
+fi
+#
+# Set runmember to default value if not GEFS cpl run
+#  (for a GFS coupled run, RUNMEN would be unset, this should default to -1)
+export RUNMEM=${RUNMEM:--1}
+# Set wave model member tags if ensemble run
+# -1: no suffix, deterministic; xxxNN: extract two last digits to make ofilename prefix=gwesNN
+if [ $RUNMEM = -1 ]; then
+# No suffix added to model ID in case of deterministic run
+  export waveMEMB=
+else
+# Extract member number only
+  export waveMEMB=`echo $RUNMEM | grep -o '..$'`
+fi
+
+# Determine if wave component needs input and/or is coupled
+export WW3ATMINP='CPL'
+export WW3ICEINP='YES'
+export WW3CURINP='YES'
+
+# Determine if input is from perturbed ensemble (T) or single input file (F) for all members
+export WW3ATMIENS='F'
+export WW3ICEIENS='F'
+export WW3CURIENS='F'
+
+echo "END: config.wave"

--- a/FV3GFSwfm/rt_ccpp_c384/config.waveinit
+++ b/FV3GFSwfm/rt_ccpp_c384/config.waveinit
@@ -1,0 +1,14 @@
+#!/bin/ksh -x
+
+########## config.waveinit ##########
+# Wave steps specific
+
+echo "BEGIN: config.waveinit"
+
+# Get task specific resources
+. $EXPDIR/config.resources waveinit
+
+# Step label
+export sigMODE=${sigMODE:-init}
+
+echo "END: config.waveinit"

--- a/FV3GFSwfm/rt_ccpp_c384/config.wavepostsbs
+++ b/FV3GFSwfm/rt_ccpp_c384/config.wavepostsbs
@@ -1,0 +1,28 @@
+#!/bin/ksh -x
+
+########## config.wavepostsbs ##########
+# Wave steps specific
+
+echo "BEGIN: config.wavepostsbs"
+
+# Get task specific resources
+. $EXPDIR/config.resources wavepostsbs
+
+
+# Subgrid info for grib2 encoding
+export WAV_SUBGRBSRC="gnh_10m"
+export WAV_SUBGRB="WAV_ATLO_GRB WAV_EPAC_GRB WAV_WCST_GRB"
+export WAV_ATLO_GRB="0 6 0 0 0 0 0 0 301 331 0 0 55000000 260000000 48 0 310000000 166667 166667 0 atlocn 0p16"
+export WAV_EPAC_GRB="0 6 0 0 0 0 0 0 511 301 0 0 30000002 130000000 48 -20000000 215000000 166667 166667 0 epacif 0p16"
+export WAV_WCST_GRB="0 6 0 0 0 0 0 0 241 151 0 0 50000000 210000000 48 25000000 250000000 166667 166667 0 wcoast 0p16"
+
+# Options for point output (switch on/off boundary point output)
+export DOIBP_WAV='NO' # Input boundary points
+export DOFLD_WAV='YES' # Field data
+export DOPNT_WAV='YES' # Station data
+export DOGRB_WAV='YES' # Create grib2 files
+export DOGRI_WAV='YES' # Create interpolated grids
+export DOSPC_WAV='YES' # Spectral post
+export DOBLL_WAV='YES' # Bulletin post
+
+echo "END: config.wavepostsbs"

--- a/FV3GFSwfm/rt_ccpp_c384/config.waveprep
+++ b/FV3GFSwfm/rt_ccpp_c384/config.waveprep
@@ -1,0 +1,46 @@
+#!/bin/ksh -x
+
+########## config.waveprep ##########
+# Wave steps specific
+
+echo "BEGIN: config.waveprep"
+
+# Get task specific resources
+. $EXPDIR/config.resources waveprep
+
+# Step label
+export sigMODE=${sigMODE:-prep}
+
+export HOUR_INC=3      # This value should match with the one used in
+                         # the wind update script
+export GOFILETYPE=1     # GOFILETYPE=1 one gridded file per output step
+export POFILETYPE=1     # POFILETYPE=1 one point file per output step
+
+# Parameters for ww3_multi.inp
+# Unified output T or F
+export FUNIPNT='T'
+# Output server type (see ww3_multi.inp in WW3 repo)
+export IOSRV='3'
+# Flag for dedicated output process for unified points
+export FPNTPROC='T'
+# Flag for grids sharing dedicated output processes
+export FGRDPROC='F'
+
+# Wind interval for standalone file-based runs
+# Output stride
+export WAV_WND_HOUR_INC=1      # This value should match with the one used in
+                         # the wind update script
+# Intake currents settings
+export WAV_CUR_DT=${WAV_CUR_DT:-3}
+export WAV_CUR_HF_DT=${WAV_CUR_HF_DT:-3} # Defaults to 3h for GEFSv12
+export WAV_CUR_HF_FH=${WAV_CUR_HF_FH:-0} # Constant DT for GFSv16 from getgo
+export WAV_CUR_CDO_SMOOTH="NO"
+
+# Location of CDO module
+export CDO_ROOT=${CDO_ROOT:-/gpfs/dell1/nco/ops/nwprod/rtofs_shared/rtofs_cdo.v1.6.0}
+
+if [ "${WW3ICEINP}" = "YES" ]; then
+  export WAVICEFILE=${CDUMP}.t${cyc}z.seaice.5min.grib2
+fi
+
+echo "END: config.waveprep"

--- a/FV3GFSwfm/rt_ccpp_c384/noent_c384.xml
+++ b/FV3GFSwfm/rt_ccpp_c384/noent_c384.xml
@@ -1,0 +1,248 @@
+<?xml version="1.0"?>
+<!DOCTYPE workflow [
+<!--
+	PROGRAM
+		Main workflow manager for Forecast only Global Forecast System
+
+	AUTHOR:
+		Rahul Mahajan
+		rahul.mahajan@noaa.gov
+
+	NOTES:
+		This workflow was automatically generated at 2021-01-28 01:39:45.113189
+	--><!-- Experiment parameters such as name, cycle, resolution --><!ENTITY PSLOT "rt_ccpp_c384">
+<!ENTITY CDUMP "gfs">
+<!ENTITY CASE "C384">
+<!-- Experiment parameters such as starting, ending dates --><!ENTITY SDATE "202103230000">
+<!ENTITY EDATE "203001100000">
+<!ENTITY INTERVAL "24:00:00">
+<!-- Run Envrionment --><!ENTITY RUN_ENVIR "emc">
+<!-- Experiment related directories --><!ENTITY EXPDIR "/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp_c384">
+<!ENTITY ROTDIR "/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp_c384">
+<!ENTITY ICSDIR "/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS">
+<!-- use RUNDIR1 as long as FV3-CHEM is still running in realtime   --><!ENTITY RUNDIR1 "/scratch1/BMC/gsd-fv3/NCEPDEV/stmp3/rtfim/RUNDIRS/rt_fv3gfs_chem">
+<!ENTITY RUNDIR "/scratch1/BMC/gsd-fv3/NCEPDEV/stmp3/rtfim/RUNDIRS/rt_ccpp_c384">
+<!-- Directories for driving the workflow --><!ENTITY HOMEgfs "/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem">
+<!ENTITY JOBS_DIR "/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/jobs/rocoto">
+<!-- Machine related entities --><!ENTITY ACCOUNT "gsd-fv3">
+<!ENTITY QUEUE_URG "urgent">
+<!ENTITY QUEUE "batch">
+<!ENTITY QUEUE_DEBUG "debug">
+<!ENTITY QUEUE_ARCH "service">
+<!ENTITY SCHEDULER "slurm">
+<!-- Toggle HPSS archiving --><!ENTITY ARCHIVE_TO_HPSS "YES">
+<!-- ROCOTO parameters that control workflow --><!ENTITY CYCLETHROTTLE "6">
+<!ENTITY TASKTHROTTLE "25">
+<!ENTITY MAXTRIES "2">
+<!-- BEGIN: Resource requirements for the workflow --><!ENTITY QUEUE_FV3IC_GFS "&QUEUE;">
+<!ENTITY WALLTIME_FV3IC_GFS "00:30:00">
+<!ENTITY RESOURCES_FV3IC_GFS "<nodes>1:ppn=1:tpp=1</nodes>">
+<!ENTITY NATIVE_FV3IC_GFS "--export=NONE">
+<!ENTITY QUEUE_CALCINC "&QUEUE;">
+<!ENTITY WALLTIME_CALCINC "00:30:00">
+<!ENTITY RESOURCES_CALCINC "<nodes>1:ppn=2</nodes>">
+<!ENTITY MEMORY_CALCINC "">
+<!ENTITY NATIVE_CALCINC "--export=NONE">
+<!ENTITY QUEUE_FCST_GFS "&QUEUE;">
+<!ENTITY WALLTIME_FCST_GFS "04:00:00">
+<!ENTITY RESOURCES_FCST_GFS "<nodes>8:ppn=40:tpp=1</nodes>">
+<!ENTITY NATIVE_FCST_GFS "--export=NONE">
+<!ENTITY QUEUE_POST_GFS "&QUEUE;">
+<!ENTITY WALLTIME_POST_GFS "00:30:00">
+<!ENTITY RESOURCES_POST_GFS "<nodes>4:ppn=12:tpp=1</nodes>">
+<!ENTITY NATIVE_POST_GFS "--export=NONE">
+<!ENTITY QUEUE_ARCH_GFS "&QUEUE;">
+<!ENTITY WALLTIME_ARCH_GFS "06:00:00">
+<!ENTITY RESOURCES_ARCH_GFS "<nodes>1:ppn=1:tpp=1</nodes>">
+<!ENTITY MEMORY_ARCH_GFS "2048M">
+<!ENTITY NATIVE_ARCH_GFS "--export=NONE">
+<!-- END: Resource requirements for the workflow -->]>
+<workflow realtime="T" scheduler="slurm" cyclethrottle="6" taskthrottle="25">
+
+	<log verbosity="10"><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp_c384/logs/@Y@m@d@H.log</cyclestr></log>
+
+	<!-- Define the cycles -->
+	<cycledef group="gfs">202103230000 203001100000 24:00:00</cycledef>
+
+<task name="gfsfv3ic" cycledefs="gfs" maxtries="2">
+
+	<command>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/jobs/rocoto/makefv3ic_link.sh</command>
+
+	<jobname><cyclestr>rt_ccpp_c384_gfsfv3ic_@H</cyclestr></jobname>
+	<account>gsd-fv3</account>
+	<queue>batch</queue>
+	<nodes>1:ppn=1:tpp=1</nodes>
+	<walltime>00:30:00</walltime>
+	
+	<native>--export=NONE</native>
+
+	<join><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp_c384/logs/@Y@m@d@H/gfsfv3ic.log</cyclestr></join>
+
+	<envar><name>ROTDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp_c384</value></envar>
+	<envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+	<envar><name>CDUMP</name><value>gfs</value></envar>
+	<envar><name>CASE</name><value>C384</value></envar>
+	<envar><name>ICSDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS</value></envar>
+
+	<dependency>
+		<and>
+			<not>
+				<datadep><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp_c384/gfs.@Y@m@d/@H/INPUT</cyclestr></datadep>
+			</not>
+			<or>
+				<and>
+					<datadep><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS/@Y@m@d@H/gfs/C384/INPUT/gfs_data.tile6.nemsio</cyclestr></datadep>
+					<datadep><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS/@Y@m@d@H/gfs/C384/INPUT/sfc_data.tile6.nemsio</cyclestr></datadep>
+				</and>
+				<and>
+					<datadep><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS/@Y@m@d@H/gfs/C384/INPUT/gfs_data.tile6.nc</cyclestr></datadep>
+					<datadep><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS/@Y@m@d@H/gfs/C384/INPUT/sfc_data.tile6.nc</cyclestr></datadep>
+				</and>
+			</or>
+		</and>
+	</dependency>
+
+</task>
+
+<task name="calcinc" cycledefs="gfs" maxtries="2">
+
+        <command>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/jobs/rocoto/calcinc.sh</command>
+
+        <jobname><cyclestr>rt_ccpp_c384_clacinc_@H</cyclestr></jobname>
+        <account>gsd-fv3</account>
+        <queue>batch</queue>
+        <nodes>1:ppn=2</nodes>
+        <walltime>00:30:00</walltime>
+        <native>--export=NONE</native>
+        <join><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp_c384/logs/@Y@m@d@H/calcinc.log</cyclestr></join>
+
+        <envar><name>RUN_ENVIR</name><value>emc</value></envar>
+        <envar><name>HOMEgfs</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem</value></envar>
+        <envar><name>OUTDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp_c384</value></envar>
+        <envar><name>ICSDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS</value></envar>
+        <envar><name>EXPDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp_c384</value></envar>
+        <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+        <envar><name>CDUMP</name><value>gfs</value></envar>
+        <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+        <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+        <dependency>
+	        <and>
+			<or>
+                      		<!--<datadep><cyclestr>&RUNDIR;/@Y@m@d@H/&CDUMP;/regrid/atmanl.@Y@m@d@H</cyclestr></datadep> -->
+                      		<!--<datadep><cyclestr>&RUNDIR;/@Y@m@d@H/&CDUMP;/regrid/atmanl.@Y@m@d@H.nc</cyclestr></datadep> -->
+                      		<datadep><cyclestr>/scratch1/BMC/gsd-fv3/NCEPDEV/stmp3/rtfim/RUNDIRS/rt_fv3gfs_chem/@Y@m@d@H/gfs/regrid/atmanl.@Y@m@d@H</cyclestr></datadep>
+                      		<datadep><cyclestr>/scratch1/BMC/gsd-fv3/NCEPDEV/stmp3/rtfim/RUNDIRS/rt_fv3gfs_chem/@Y@m@d@H/gfs/regrid/atmanl.@Y@m@d@H.nc</cyclestr></datadep>
+			</or>
+	              <datadep><cyclestr offset="-24:00:00">/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp_c384/gfs.@Y@m@d/@H/gfs.t@Hz.atmf024.nemsio</cyclestr></datadep>  
+                </and> 
+        </dependency>
+</task> 
+
+<task name="gfsfcst" cycledefs="gfs" maxtries="2">
+
+	<command>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/jobs/rocoto/fcst.sh</command>
+
+	<jobname><cyclestr>rt_ccpp_c384_gfsfcst_@H</cyclestr></jobname>
+	<account>gsd-fv3</account>
+	<queue>batch</queue>
+	<nodes>8:ppn=40:tpp=1</nodes>
+	<walltime>04:00:00</walltime>
+	
+	<native>--export=NONE</native>
+
+	<join><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp_c384/logs/@Y@m@d@H/gfsfcst.log</cyclestr></join>
+
+	<envar><name>RUN_ENVIR</name><value>emc</value></envar>
+	<envar><name>HOMEgfs</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem</value></envar>
+	<envar><name>EXPDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp_c384</value></envar>
+	<envar><name>ROTDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp_c384</value></envar>
+	<envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+	<envar><name>CDUMP</name><value>gfs</value></envar>
+	<envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+	<envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+	<envar><name>ROTDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp_c384</value></envar>
+
+	<dependency>
+		<and>
+                       <taskdep task="calcinc"/>
+                       <datadep><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp_c384/gfs.@Y@m@d/@H/INPUT</cyclestr></datadep>
+                       <datadep><cyclestr>/scratch1/BMC/gsd-fv3/NCEPDEV/stmp3/rtfim/RUNDIRS/rt_ccpp_c384/@Y@m@d@H/gfs/calcinc/atminc.nc</cyclestr></datadep>
+                       <datadep><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS/@Y@m@d@H/gfs/C384/INPUT/sfc_data.tile6.nc</cyclestr></datadep>
+                       <datadep><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS/@Y@m@d@H/gfs/C384/INPUT/gfs_data.tile6.nc</cyclestr></datadep>
+               </and>
+        </dependency>
+</task> 
+
+<metatask name="gfspost">
+
+	<var name="grp">001 002 003 004 005 006 007 008 009 010 011 012 013 014 015 016 017 018 019 020 021 022 023 024 025 026 027 028 029</var>
+	<var name="dep">f000 f006 f012 f018 f024 f030 f036 f042 f048 f054 f060 f066 f072 f078 f084 f090 f096 f102 f108 f114 f120 f126 f132 f138 f144 f150 f156 f162 f168</var>
+	<var name="lst">f000 f006 f012 f018 f024 f030 f036 f042 f048 f054 f060 f066 f072 f078 f084 f090 f096 f102 f108 f114 f120 f126 f132 f138 f144 f150 f156 f162 f168</var>
+
+	<task name="gfspost#grp#" cycledefs="gfs" maxtries="2">
+
+		<command>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/jobs/rocoto/post.sh</command>
+
+		<jobname><cyclestr>rt_ccpp_c384_gfspost#grp#_@H</cyclestr></jobname>
+		<account>gsd-fv3</account>
+		<queue>batch</queue>
+		<nodes>4:ppn=12:tpp=1</nodes>
+		<walltime>00:30:00</walltime>
+		
+		<native>--export=NONE</native>
+
+		<join><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp_c384/logs/@Y@m@d@H/gfspost#grp#.log</cyclestr></join>
+
+		<envar><name>RUN_ENVIR</name><value>emc</value></envar>
+		<envar><name>HOMEgfs</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem</value></envar>
+		<envar><name>EXPDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp_c384</value></envar>
+		<envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+		<envar><name>CDUMP</name><value>gfs</value></envar>
+		<envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+		<envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+		<envar><name>FHRGRP</name><value>#grp#</value></envar>
+		<envar><name>FHRLST</name><value>#lst#</value></envar>
+		<envar><name>ROTDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp_c384</value></envar>
+
+		<dependency>
+			<datadep><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp_c384/gfs.@Y@m@d/@H/gfs.t@Hz.log#dep#.txt</cyclestr></datadep>
+		</dependency>
+
+	</task>
+
+</metatask>
+
+<task name="gfsarch" cycledefs="gfs" maxtries="2" final="true">
+
+	<command>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/jobs/rocoto/arch_gsd.sh</command>
+
+	<jobname><cyclestr>rt_ccpp_c384_gfsarch_@H</cyclestr></jobname>
+	<account>gsd-fv3</account>
+	<queue>batch</queue>
+	<nodes>1:ppn=1:tpp=1</nodes>
+	<walltime>06:00:00</walltime>
+	<memory>2048M</memory>
+	<native>--export=NONE</native>
+
+	<join><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp_c384/logs/@Y@m@d@H/gfsarch.log</cyclestr></join>
+
+	<envar><name>RUN_ENVIR</name><value>emc</value></envar>
+	<envar><name>HOMEgfs</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem</value></envar>
+	<envar><name>EXPDIR</name><value>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp_c384</value></envar>
+	<envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+	<envar><name>CDUMP</name><value>gfs</value></envar>
+	<envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+	<envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+
+	<dependency>
+		<and>
+			<metataskdep metatask="gfspost"/>
+			<streq><left>YES</left><right>YES</right></streq>
+                        <datadep age="600"><cyclestr>/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp_c384/gfs.@Y@m@d/@H/ncl/a2/files.zip</cyclestr></datadep>
+		</and>
+	</dependency>
+
+</task>
+
+
+</workflow>

--- a/FV3GFSwfm/rt_ccpp_c384/rt_ccpp_c384.crontab
+++ b/FV3GFSwfm/rt_ccpp_c384/rt_ccpp_c384.crontab
@@ -1,0 +1,6 @@
+
+#################### rt_ccpp_c384 ####################
+MAILTO=""
+*/5 * * * * /apps/rocoto/1.3.3/bin/rocotorun -d /scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp_c384/rt_ccpp_c384.db -w /scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp_c384/rt_ccpp_c384.xml
+#################################################################
+

--- a/FV3GFSwfm/rt_ccpp_c384/rt_ccpp_c384.xml
+++ b/FV3GFSwfm/rt_ccpp_c384/rt_ccpp_c384.xml
@@ -1,0 +1,283 @@
+<?xml version="1.0"?>
+<!DOCTYPE workflow
+[
+	<!--
+	PROGRAM
+		Main workflow manager for Forecast only Global Forecast System
+
+	AUTHOR:
+		Rahul Mahajan
+		rahul.mahajan@noaa.gov
+
+	NOTES:
+		This workflow was automatically generated at 2021-01-28 01:39:45.113189
+	-->
+
+	<!-- Experiment parameters such as name, cycle, resolution -->
+	<!ENTITY PSLOT    "rt_ccpp_c384">
+	<!ENTITY CDUMP    "gfs">
+	<!ENTITY CASE     "C384">
+
+	<!-- Experiment parameters such as starting, ending dates -->
+	<!ENTITY SDATE    "202103230000">
+	<!ENTITY EDATE    "203001100000">
+	<!ENTITY INTERVAL "24:00:00">
+
+	<!-- Run Envrionment -->
+	<!ENTITY RUN_ENVIR "emc">
+
+	<!-- Experiment related directories -->
+	<!ENTITY EXPDIR "/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp_c384">
+	<!ENTITY ROTDIR "/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSrun/rt_ccpp_c384">
+	<!ENTITY ICSDIR "/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3ICS">
+
+        <!-- use RUNDIR1 as long as FV3-CHEM is still running in realtime   -->
+        <!ENTITY RUNDIR1 "/scratch1/BMC/gsd-fv3/NCEPDEV/stmp3/rtfim/RUNDIRS/rt_fv3gfs_chem">
+        <!ENTITY RUNDIR "/scratch1/BMC/gsd-fv3/NCEPDEV/stmp3/rtfim/RUNDIRS/rt_ccpp_c384">
+
+	<!-- Directories for driving the workflow -->
+	<!ENTITY HOMEgfs  "/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem">
+	<!ENTITY JOBS_DIR "/scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/jobs/rocoto">
+
+	<!-- Machine related entities -->
+	<!ENTITY ACCOUNT    "gsd-fv3">
+	<!ENTITY QUEUE_URG  "urgent">
+	<!ENTITY QUEUE      "batch">
+	<!ENTITY QUEUE_DEBUG  "debug">
+	<!ENTITY QUEUE_ARCH "service">
+	<!ENTITY SCHEDULER  "slurm">
+
+	<!-- Toggle HPSS archiving -->
+	<!ENTITY ARCHIVE_TO_HPSS "YES">
+
+	<!-- ROCOTO parameters that control workflow -->
+	<!ENTITY CYCLETHROTTLE "6">
+	<!ENTITY TASKTHROTTLE  "25">
+	<!ENTITY MAXTRIES      "2">
+
+	<!-- BEGIN: Resource requirements for the workflow -->
+
+	<!ENTITY QUEUE_FV3IC_GFS     "&QUEUE;">
+	<!ENTITY WALLTIME_FV3IC_GFS  "00:30:00">
+	<!ENTITY RESOURCES_FV3IC_GFS "<nodes>1:ppn=1:tpp=1</nodes>">
+	<!ENTITY NATIVE_FV3IC_GFS    "--export=NONE">
+
+        <!ENTITY QUEUE_CALCINC     "&QUEUE;">
+        <!ENTITY WALLTIME_CALCINC  "00:30:00">
+        <!ENTITY RESOURCES_CALCINC "<nodes>1:ppn=2</nodes>">
+        <!ENTITY MEMORY_CALCINC    "">
+        <!ENTITY NATIVE_CALCINC    "--export=NONE">
+
+	<!ENTITY QUEUE_FCST_GFS     "&QUEUE;">
+	<!ENTITY QUEUE_FCST_GFS     "&QUEUE_URG;">
+	<!ENTITY QUEUE_FCST_GFS     "&QUEUE_DEBUG;">
+	<!ENTITY WALLTIME_FCST_GFS  "04:00:00">
+	<!ENTITY WALLTIME_FCST_GFS  "00:30:00">
+	<!ENTITY RESOURCES_FCST_GFS "<nodes>8:ppn=40:tpp=1</nodes>">
+	<!ENTITY NATIVE_FCST_GFS    "--export=NONE">
+
+	<!ENTITY QUEUE_POST_GFS     "&QUEUE;">
+	<!ENTITY QUEUE_POST_GFS     "&QUEUE_DEBUG;">
+	<!ENTITY WALLTIME_POST_GFS  "00:30:00">
+	<!ENTITY RESOURCES_POST_GFS "<nodes>4:ppn=12:tpp=1</nodes>">
+	<!ENTITY NATIVE_POST_GFS    "--export=NONE">
+
+	<!ENTITY QUEUE_ARCH_GFS     "&QUEUE;">
+	<!ENTITY WALLTIME_ARCH_GFS  "06:00:00">
+	<!ENTITY RESOURCES_ARCH_GFS "<nodes>1:ppn=1:tpp=1</nodes>">
+	<!ENTITY MEMORY_ARCH_GFS    "2048M">
+	<!ENTITY NATIVE_ARCH_GFS    "--export=NONE">
+
+	<!-- END: Resource requirements for the workflow -->
+
+]>
+
+<workflow realtime="T" scheduler="&SCHEDULER;" cyclethrottle="&CYCLETHROTTLE;" taskthrottle="&TASKTHROTTLE;">
+
+	<log verbosity="10"><cyclestr>&EXPDIR;/logs/@Y@m@d@H.log</cyclestr></log>
+
+	<!-- Define the cycles -->
+	<cycledef group="gfs">&SDATE; &EDATE; &INTERVAL;</cycledef>
+
+<task name="gfsfv3ic" cycledefs="gfs" maxtries="&MAXTRIES;">
+
+	<command>&JOBS_DIR;/makefv3ic_link.sh</command>
+
+	<jobname><cyclestr>&PSLOT;_gfsfv3ic_@H</cyclestr></jobname>
+	<account>&ACCOUNT;</account>
+	<queue>&QUEUE_FV3IC_GFS;</queue>
+	&RESOURCES_FV3IC_GFS;
+	<walltime>&WALLTIME_FV3IC_GFS;</walltime>
+	
+	<native>&NATIVE_FV3IC_GFS;</native>
+
+	<join><cyclestr>&ROTDIR;/logs/@Y@m@d@H/gfsfv3ic.log</cyclestr></join>
+
+	<envar><name>ROTDIR</name><value>&ROTDIR;</value></envar>
+	<envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+	<envar><name>CDUMP</name><value>&CDUMP;</value></envar>
+	<envar><name>CASE</name><value>&CASE;</value></envar>
+	<envar><name>ICSDIR</name><value>&ICSDIR;</value></envar>
+
+	<dependency>
+		<and>
+			<not>
+				<datadep><cyclestr>&ROTDIR;/&CDUMP;.@Y@m@d/@H/INPUT</cyclestr></datadep>
+			</not>
+			<or>
+				<and>
+					<datadep><cyclestr>&ICSDIR;/@Y@m@d@H/&CDUMP;/&CASE;/INPUT/gfs_data.tile6.nemsio</cyclestr></datadep>
+					<datadep><cyclestr>&ICSDIR;/@Y@m@d@H/&CDUMP;/&CASE;/INPUT/sfc_data.tile6.nemsio</cyclestr></datadep>
+				</and>
+				<and>
+					<datadep><cyclestr>&ICSDIR;/@Y@m@d@H/&CDUMP;/&CASE;/INPUT/gfs_data.tile6.nc</cyclestr></datadep>
+					<datadep><cyclestr>&ICSDIR;/@Y@m@d@H/&CDUMP;/&CASE;/INPUT/sfc_data.tile6.nc</cyclestr></datadep>
+				</and>
+			</or>
+		</and>
+	</dependency>
+
+</task>
+
+<task name="calcinc" cycledefs="gfs" maxtries="&MAXTRIES;">
+
+        <command>&JOBS_DIR;/calcinc.sh</command>
+
+        <jobname><cyclestr>&PSLOT;_clacinc_@H</cyclestr></jobname>
+        <account>&ACCOUNT;</account>
+        <queue>&QUEUE_CALCINC;</queue>
+        &RESOURCES_CALCINC;
+        <walltime>&WALLTIME_CALCINC;</walltime>
+        <native>&NATIVE_CALCINC;</native>
+        <join><cyclestr>&ROTDIR;/logs/@Y@m@d@H/calcinc.log</cyclestr></join>
+
+        <envar><name>RUN_ENVIR</name><value>&RUN_ENVIR;</value></envar>
+        <envar><name>HOMEgfs</name><value>&HOMEgfs;</value></envar>
+        <envar><name>OUTDIR</name><value>&ROTDIR;</value></envar>
+        <envar><name>ICSDIR</name><value>&ICSDIR;</value></envar>
+        <envar><name>EXPDIR</name><value>&EXPDIR;</value></envar>
+        <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+        <envar><name>CDUMP</name><value>&CDUMP;</value></envar>
+        <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+        <envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+        <dependency>
+	        <and>
+			<or>
+                      		<!--<datadep><cyclestr>&RUNDIR;/@Y@m@d@H/&CDUMP;/regrid/atmanl.@Y@m@d@H</cyclestr></datadep> -->
+                      		<!--<datadep><cyclestr>&RUNDIR;/@Y@m@d@H/&CDUMP;/regrid/atmanl.@Y@m@d@H.nc</cyclestr></datadep> -->
+                      		<datadep><cyclestr>&RUNDIR1;/@Y@m@d@H/&CDUMP;/regrid/atmanl.@Y@m@d@H</cyclestr></datadep>
+                      		<datadep><cyclestr>&RUNDIR1;/@Y@m@d@H/&CDUMP;/regrid/atmanl.@Y@m@d@H.nc</cyclestr></datadep>
+			</or>
+	              <datadep><cyclestr offset="-24:00:00">&ROTDIR;/&CDUMP;.@Y@m@d/@H/&CDUMP;.t@Hz.atmf024.nemsio</cyclestr></datadep>  
+                </and> 
+        </dependency>
+</task> 
+
+<task name="gfsfcst" cycledefs="gfs" maxtries="&MAXTRIES;">
+
+	<command>&JOBS_DIR;/fcst.sh</command>
+
+	<jobname><cyclestr>&PSLOT;_gfsfcst_@H</cyclestr></jobname>
+	<account>&ACCOUNT;</account>
+	<queue>&QUEUE_FCST_GFS;</queue>
+	&RESOURCES_FCST_GFS;
+	<walltime>&WALLTIME_FCST_GFS;</walltime>
+	
+	<native>&NATIVE_FCST_GFS;</native>
+
+	<join><cyclestr>&ROTDIR;/logs/@Y@m@d@H/gfsfcst.log</cyclestr></join>
+
+	<envar><name>RUN_ENVIR</name><value>&RUN_ENVIR;</value></envar>
+	<envar><name>HOMEgfs</name><value>&HOMEgfs;</value></envar>
+	<envar><name>EXPDIR</name><value>&EXPDIR;</value></envar>
+	<envar><name>ROTDIR</name><value>&ROTDIR;</value></envar>
+	<envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+	<envar><name>CDUMP</name><value>&CDUMP;</value></envar>
+	<envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+	<envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+	<envar><name>ROTDIR</name><value>&ROTDIR;</value></envar>
+
+	<dependency>
+		<and>
+                       <taskdep task="calcinc"/>
+                       <datadep><cyclestr>&ROTDIR;/gfs.@Y@m@d/@H/INPUT</cyclestr></datadep>
+                       <datadep><cyclestr>&RUNDIR;/@Y@m@d@H/&CDUMP;/calcinc/atminc.nc</cyclestr></datadep>
+                       <datadep><cyclestr>&ICSDIR;/@Y@m@d@H/&CDUMP;/&CASE;/INPUT/sfc_data.tile6.nc</cyclestr></datadep>
+                       <datadep><cyclestr>&ICSDIR;/@Y@m@d@H/&CDUMP;/&CASE;/INPUT/gfs_data.tile6.nc</cyclestr></datadep>
+               </and>
+        </dependency>
+</task> 
+
+<metatask name="gfspost">
+
+	<var name="grp">001 002 003 004 005 006 007 008 009 010 011 012 013 014 015 016 017 018 019 020 021 022 023 024 025 026 027 028 029</var>
+	<var name="dep">f000 f006 f012 f018 f024 f030 f036 f042 f048 f054 f060 f066 f072 f078 f084 f090 f096 f102 f108 f114 f120 f126 f132 f138 f144 f150 f156 f162 f168</var>
+	<var name="lst">f000 f006 f012 f018 f024 f030 f036 f042 f048 f054 f060 f066 f072 f078 f084 f090 f096 f102 f108 f114 f120 f126 f132 f138 f144 f150 f156 f162 f168</var>
+
+	<task name="gfspost#grp#" cycledefs="gfs" maxtries="&MAXTRIES;">
+
+		<command>&JOBS_DIR;/post.sh</command>
+
+		<jobname><cyclestr>&PSLOT;_gfspost#grp#_@H</cyclestr></jobname>
+		<account>&ACCOUNT;</account>
+		<queue>&QUEUE_POST_GFS;</queue>
+		&RESOURCES_POST_GFS;
+		<walltime>&WALLTIME_POST_GFS;</walltime>
+		
+		<native>&NATIVE_POST_GFS;</native>
+
+		<join><cyclestr>&ROTDIR;/logs/@Y@m@d@H/gfspost#grp#.log</cyclestr></join>
+
+		<envar><name>RUN_ENVIR</name><value>&RUN_ENVIR;</value></envar>
+		<envar><name>HOMEgfs</name><value>&HOMEgfs;</value></envar>
+		<envar><name>EXPDIR</name><value>&EXPDIR;</value></envar>
+		<envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+		<envar><name>CDUMP</name><value>&CDUMP;</value></envar>
+		<envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+		<envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+		<envar><name>FHRGRP</name><value>#grp#</value></envar>
+		<envar><name>FHRLST</name><value>#lst#</value></envar>
+		<envar><name>ROTDIR</name><value>&ROTDIR;</value></envar>
+
+		<dependency>
+			<datadep><cyclestr>&ROTDIR;/gfs.@Y@m@d/@H/gfs.t@Hz.log#dep#.txt</cyclestr></datadep>
+		</dependency>
+
+	</task>
+
+</metatask>
+
+<task name="gfsarch" cycledefs="gfs" maxtries="&MAXTRIES;" final="true">
+
+	<command>&JOBS_DIR;/arch_gsd.sh</command>
+
+	<jobname><cyclestr>&PSLOT;_gfsarch_@H</cyclestr></jobname>
+	<account>&ACCOUNT;</account>
+	<queue>&QUEUE_ARCH_GFS;</queue>
+	&RESOURCES_ARCH_GFS;
+	<walltime>&WALLTIME_ARCH_GFS;</walltime>
+	<memory>&MEMORY_ARCH_GFS;</memory>
+	<native>&NATIVE_ARCH_GFS;</native>
+
+	<join><cyclestr>&ROTDIR;/logs/@Y@m@d@H/gfsarch.log</cyclestr></join>
+
+	<envar><name>RUN_ENVIR</name><value>&RUN_ENVIR;</value></envar>
+	<envar><name>HOMEgfs</name><value>&HOMEgfs;</value></envar>
+	<envar><name>EXPDIR</name><value>&EXPDIR;</value></envar>
+	<envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+	<envar><name>CDUMP</name><value>&CDUMP;</value></envar>
+	<envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+	<envar><name>cyc</name><value><cyclestr>@H</cyclestr></value></envar>
+
+	<dependency>
+		<and>
+			<metataskdep metatask="gfspost"/>
+			<streq><left>&ARCHIVE_TO_HPSS;</left><right>YES</right></streq>
+                        <datadep age="600"><cyclestr>&ROTDIR;/&CDUMP;.@Y@m@d/@H/ncl/a2/files.zip</cyclestr></datadep>
+		</and>
+	</dependency>
+
+</task>
+
+
+</workflow>

--- a/FV3GFSwfm/rt_ccpp_c384/run_cmds
+++ b/FV3GFSwfm/rt_ccpp_c384/run_cmds
@@ -1,0 +1,10 @@
+REALTIME
+========
+rocotorun -w /scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp_c384/rt_ccpp_c384.xml -d /home/rtfim/rt_dbfiles/rt_ccpp_c384.db
+rocotostat  -w /scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp_c384/rt_ccpp_c384.xml -d /home/rtfim/rt_dbfiles/rt_ccpp_c384.db -c `date --date='4 days ago' +%Y%m%d0000`: | m
+
+rocotorun -w /scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp_c384/ccpp_c384.xml -d /home/rtfim/retro_dbfiles/ccpp_c384.db
+rocotostat -w /scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp_c384/ccpp_c384.xml -d /home/rtfim/retro_dbfiles/ccpp_c384.db | m
+
+rocotorun -w /scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp_c384/ccpp_c384_arch.xml -d /home/rtfim/retro_dbfiles/ccpp_c384_arch.db
+rocotostat -w /scratch1/BMC/gsd-fv3/rtruns/CCPP-Chem/FV3GFSwfm/rt_ccpp_c384/ccpp_c384_arch.xml -d /home/rtfim/retro_dbfiles/ccpp_c384_arch.db | m

--- a/jobs/rocoto/calcinc_gfsv16.sh-retro
+++ b/jobs/rocoto/calcinc_gfsv16.sh-retro
@@ -51,7 +51,6 @@ if [ $DO_CALC_INCREMENT = "YES" ]; then
 
   [[ ! -d $DATA ]] && mkdir -p $DATA
   cd $DATA
-  ln -sf $RUNDIR1/$CDATE/$CDUMP/regrid regrid #lzhang
   mkdir -p calcinc
   cd calcinc
 

--- a/parm/parm_fv3diag/field_table_gfdl_gsd
+++ b/parm/parm_fv3diag/field_table_gfdl_gsd
@@ -1,0 +1,42 @@
+# added by FRE: sphum must be present in atmos
+# specific humidity for moist runs
+ "TRACER", "atmos_mod", "sphum"
+           "longname",     "specific humidity"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic cloud water mixing ratio
+ "TRACER", "atmos_mod", "liq_wat"
+           "longname",     "cloud water mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+ "TRACER", "atmos_mod", "rainwat"
+           "longname",     "rain mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+ "TRACER", "atmos_mod", "ice_wat"
+           "longname",     "cloud ice mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+ "TRACER", "atmos_mod", "snowwat"
+           "longname",     "snow mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+ "TRACER", "atmos_mod", "graupel"
+           "longname",     "graupel mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic ozone mixing ratio tracer
+ "TRACER", "atmos_mod", "o3mr"
+           "longname",     "ozone mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic subgrid scale turbulent kinetic energy
+ "TRACER", "atmos_mod", "sgs_tke"
+           "longname",     "subgrid scale turbulent kinetic energy"
+           "units",        "m2/s2"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# non-prognostic cloud amount
+ "TRACER", "atmos_mod", "cld_amt"
+           "longname",     "cloud amount"
+           "units",        "1"
+       "profile_type", "fixed", "surface_value=1.e30" /

--- a/scripts/exglobal_fcst_nemsfv3gfs_nochem.sh
+++ b/scripts/exglobal_fcst_nemsfv3gfs_nochem.sh
@@ -1,0 +1,1446 @@
+#!/bin/ksh
+################################################################################
+# UNIX Script Documentation Block
+# Script name:         exglobal_fcst_nemsfv3gfs.sh.ecf
+# Script description:  Runs a global FV3GFS model forecast
+#
+# Author:   Fanglin Yang       Org: NCEP/EMC       Date: 2016-11-15
+# Abstract: This script runs a single GFS forecast with FV3 dynamical core.
+#           This script is created based on a C-shell script that GFDL wrote
+#           for the NGGPS Phase-II Dycore Comparison Project.
+#
+# Script history log:
+# 2016-11-15  Fanglin Yang   First Version.
+# 2017-02-09  Rahul Mahajan  Added warm start and restructured the code.
+# 2017-03-10  Fanglin Yang   Updated for running forecast on Cray.
+# 2017-03-24  Fanglin Yang   Updated to use NEMS FV3GFS with IPD4
+# 2017-05-24  Rahul Mahajan  Updated for cycling with NEMS FV3GFS
+# 2017-09-13  Fanglin Yang   Updated for using GFDL MP and Write Component
+# 2019-03-05  Rahul Mahajan  Implemented IAU
+# 2019-03-21  Fanglin Yang   Add restart capability for running gfs fcst from a break point.
+# 2019-12-12  Henrique Alves Added wave model blocks for coupled run
+# 2020-01-31  Henrique Alves Added IAU capability for wave component
+# 2020-06-02  Fanglin Yang   restore restart capability when IAU is turned on.                     
+#
+# $Id$
+#
+# Attributes:
+#   Language: Portable Operating System Interface (POSIX) Shell
+#   Machine: WCOSS-CRAY, Theia
+################################################################################
+
+#  Set environment.
+VERBOSE=${VERBOSE:-"YES"}
+if [ $VERBOSE = "YES" ] ; then
+  echo $(date) EXECUTING $0 $* >&2
+  set -x
+fi
+
+machine=${machine:-"WCOSS_C"}
+machine=$(echo $machine | tr '[a-z]' '[A-Z]')
+
+# Cycling and forecast hour specific parameters 
+CASE=${CASE:-C768}
+CDATE=${CDATE:-2017032500}
+CDUMP=${CDUMP:-gfs}
+FHMIN=${FHMIN:-0}
+FHMAX=${FHMAX:-9}
+FHOUT=${FHOUT:-6}
+FHZER=${FHZER:-6}
+FHCYC=${FHCYC:-24}
+FHMAX_HF=${FHMAX_HF:-0}
+FHOUT_HF=${FHOUT_HF:-1}
+NSOUT=${NSOUT:-"-1"}
+FDIAG=$FHOUT
+if [ $FHMAX_HF -gt 0 -a $FHOUT_HF -gt 0 ]; then FDIAG=$FHOUT_HF; fi
+WRITE_DOPOST=${WRITE_DOPOST:-".false."}
+restart_interval=${restart_interval:-0}
+rst_invt1=`echo $restart_interval |cut -d " " -f 1`
+
+PDY=$(echo $CDATE | cut -c1-8)
+cyc=$(echo $CDATE | cut -c9-10)
+
+# Directories.
+pwd=$(pwd)
+NWPROD=${NWPROD:-${NWROOT:-$pwd}}
+HOMEgfs=${HOMEgfs:-$NWPROD}
+FIX_DIR=${FIX_DIR:-$HOMEgfs/fix}
+FIX_AM=${FIX_AM:-$FIX_DIR/fix_am}
+FIXfv3=${FIXfv3:-$FIX_DIR/fix_fv3_gmted2010}
+DATA=${DATA:-$pwd/fv3tmp$$}    # temporary running directory
+ROTDIR=${ROTDIR:-$pwd}         # rotating archive directory
+ICSDIR=${ICSDIR:-$pwd}         # cold start initial conditions
+DMPDIR=${DMPDIR:-$pwd}         # global dumps for seaice, snow and sst analysis
+EMIDIR=${EMIDIR:-$pwd}         # anthro. emission 
+EMITYPE=${EMITYPE:-1}         # 1:MODIS, 2:GBBEPx 
+# Model resolution specific parameters
+DELTIM=${DELTIM:-225}
+layout_x=${layout_x:-8}
+layout_y=${layout_y:-16}
+LEVS=${LEVS:-65}
+
+# Utilities
+NCP=${NCP:-"/bin/cp -p"}
+NLN=${NLN:-"/bin/ln -sf"}
+NMV=${NMV:-"/bin/mv"}
+SEND=${SEND:-"YES"}   #move final result to rotating directory
+ERRSCRIPT=${ERRSCRIPT:-'eval [[ $err = 0 ]]'}
+KEEPDATA=${KEEPDATA:-"NO"}
+
+# Other options
+MEMBER=${MEMBER:-"-1"} # -1: control, 0: ensemble mean, >0: ensemble member $MEMBER
+ENS_NUM=${ENS_NUM:-1}  # Single executable runs multiple members (e.g. GEFS)
+PREFIX_ATMINC=${PREFIX_ATMINC:-""} # allow ensemble to use recentered increment
+
+# IAU options
+DOIAU=${DOIAU:-"NO"}
+IAUFHRS=${IAUFHRS:-0}
+IAU_DELTHRS=${IAU_DELTHRS:-0}
+IAU_OFFSET=${IAU_OFFSET:-0}
+
+# Model specific stuff
+FCSTEXECDIR=${FCSTEXECDIR:-$HOMEgfs/sorc/fv3gfs.fd/NEMS/exe}
+FCSTEXEC=${FCSTEXEC:-fv3_gfs.x}
+PARM_FV3DIAG=${PARM_FV3DIAG:-$HOMEgfs/parm/parm_fv3diag}
+PARM_POST=${PARM_POST:-$HOMEgfs/parm/post}
+
+# Wave coupling parameter defaults to false
+cplwav=${cplwav:-.false.}
+
+# Chem coupling parameter defaults to true
+cplchm=${cplchm:-.true.}
+
+# Model config options
+APRUN_FV3=${APRUN_FV3:-${APRUN_FCST:-${APRUN:-""}}}
+NTHREADS_FV3=${NTHREADS_FV3:-${NTHREADS_FCST:-${nth_fv3:-1}}}
+cores_per_node=${cores_per_node:-${npe_node_max:-24}}
+ntiles=${ntiles:-6}
+NTASKS_FV3=${NTASKS_FV3:-$npe_fv3}
+
+TYPE=${TYPE:-"nh"}                  # choices:  nh, hydro
+MONO=${MONO:-"non-mono"}            # choices:  mono, non-mono
+
+QUILTING=${QUILTING:-".true."}
+OUTPUT_GRID=${OUTPUT_GRID:-"gaussian_grid"}
+OUTPUT_FILE=${OUTPUT_FILE:-"nemsio"}
+WRITE_NEMSIOFLIP=${WRITE_NEMSIOFLIP:-".true."}
+WRITE_FSYNCFLAG=${WRITE_FSYNCFLAG:-".true."}
+affix="nemsio"
+[[ "$OUTPUT_FILE" = "netcdf" ]] && affix="nc"
+
+rCDUMP=${rCDUMP:-$CDUMP}
+
+#------------------------------------------------------------------
+# setup the runtime environment
+if [ $machine = "WCOSS_C" ] ; then
+  HUGEPAGES=${HUGEPAGES:-hugepages4M}
+  . $MODULESHOME/init/sh 2>/dev/null
+  module load iobuf craype-$HUGEPAGES 2>/dev/null
+  export MPICH_GNI_COLL_OPT_OFF=${MPICH_GNI_COLL_OPT_OFF:-MPI_Alltoallv}
+  export MKL_CBWR=AVX2
+  export WRTIOBUF=${WRTIOBUF:-"4M"}
+  export NC_BLKSZ=${NC_BLKSZ:-"4M"}
+  export IOBUF_PARAMS="*nemsio:verbose:size=${WRTIOBUF},*:verbose:size=${NC_BLKSZ}"
+fi
+
+#-------------------------------------------------------
+if [ ! -d $ROTDIR ]; then mkdir -p $ROTDIR; fi
+mkdata=NO
+if [ ! -d $DATA ]; then
+#   mkdata=YES #lzhang do not clean the RUNDIR
+   mkdir -p $DATA
+fi
+
+# Stage the FV3 initial conditions to ROTDIR  
+export OUTDIR="$ICSDIR/$CDATE/$CDUMP/$CASE/INPUT" #lzhang
+COMOUT="$ROTDIR/$CDUMP.$PDY/$cyc"
+[[ ! -d $COMOUT ]] && mkdir -p $COMOUT
+cd $COMOUT || exit 99
+[[ ! -d $INPUT ]] && $NLN $OUTDIR .
+#----------------------------------------------------
+cd $DATA || exit 8
+mkdir -p $DATA/INPUT
+
+if [ $cplwav = ".true." ]; then 
+    if [ $CDUMP = "gdas" ]; then
+        RSTDIR_WAVE=$ROTDIR/${CDUMP}wave.${PDY}/${cyc}/restart
+    else
+        RSTDIR_WAVE=${RSTDIR_WAVE:-$ROTDIR/${CDUMP}wave.${PDY}/${cyc}/restart}
+    fi
+    if [ ! -d $RSTDIR_WAVE ]; then mkdir -p $RSTDIR_WAVE ; fi
+    $NLN $RSTDIR_WAVE restart_wave
+fi
+
+#lzhang we do not need so much restart file in the output
+if [ $CDUMP = "gfs" -a $restart_interval -gt 0 ]; then
+    RSTDIR_TMP=${RSTDIR:-$ROTDIR}/${CDUMP}.${PDY}/${cyc}/RERUN_RESTART
+    rm -rf  RSTDIR_TMP #lzhang temperal setting
+    if [ ! -d $RSTDIR_TMP ]; then mkdir -p $RSTDIR_TMP ; fi
+    $NLN $RSTDIR_TMP RESTART
+else
+    mkdir -p $DATA/RESTART
+fi
+
+#-------------------------------------------------------
+# determine if restart IC exists to continue from a previous forecast
+RERUN="NO"
+filecount=$(find $RSTDIR_ATM -type f | wc -l) 
+if [ $CDUMP = "gfs" -a $rst_invt1 -gt 0 -a $FHMAX -gt $rst_invt1 -a $filecount -gt 10 ]; then
+    reverse=$(echo "${restart_interval[@]} " | tac -s ' ')
+    for xfh in $reverse ; do
+        yfh=$((xfh-(IAU_OFFSET/2)))
+        SDATE=$($NDATE +$yfh $CDATE)
+        PDYS=$(echo $SDATE | cut -c1-8)
+        cycs=$(echo $SDATE | cut -c9-10)
+        flag1=$RSTDIR_ATM/${PDYS}.${cycs}0000.coupler.res
+        flag2=$RSTDIR_ATM/coupler.res
+        if [ -s $flag1 ]; then
+            CDATE_RST=$SDATE          
+            [[ $RERUN = "YES" ]] && break
+            mv $flag1 ${flag1}.old
+            if [ -s $flag2 ]; then mv $flag2 ${flag2}.old ;fi
+            RERUN="YES"
+            [[ $xfh = $rst_invt1 ]] && RERUN="NO"
+        fi 
+    done
+fi
+
+#-------------------------------------------------------
+# member directory
+if [ $MEMBER -lt 0 ]; then
+  prefix=$CDUMP
+  rprefix=$rCDUMP
+  memchar=""
+else
+  prefix=enkf$CDUMP
+  rprefix=enkf$rCDUMP
+  memchar=mem$(printf %03i $MEMBER)
+fi
+memdir=$ROTDIR/${prefix}.$PDY/$cyc/$memchar
+if [ ! -d $memdir ]; then mkdir -p $memdir; fi
+
+GDATE=$($NDATE -$assim_freq $CDATE)
+gPDY=$(echo $GDATE | cut -c1-8)
+gcyc=$(echo $GDATE | cut -c9-10)
+#gmemdir=$ROTDIR/${rprefix}.$gPDY/$gcyc/$memchar !lzhang
+gmemdir=$ROTDIR/${prefix}.$gPDY/$gcyc/$memchar
+sCDATE=$($NDATE -3 $CDATE)
+
+if [[ "$DOIAU" = "YES" ]]; then
+  sCDATE=$($NDATE -3 $CDATE)
+  sPDY=$(echo $sCDATE | cut -c1-8)
+  scyc=$(echo $sCDATE | cut -c9-10)
+  tPDY=$gPDY
+  tcyc=$gcyc
+else
+  sCDATE=$CDATE
+  sPDY=$PDY
+  scyc=$cyc
+  tPDY=$sPDY
+  tcyc=$cyc
+fi
+
+#-------------------------------------------------------
+# initial conditions
+warm_start=${warm_start:-".false."}
+read_increment=${read_increment:-".false."}
+res_latlon_dynamics="''"
+
+# Determine if this is a warm start or cold start
+if [ -f $gmemdir/RESTART/${sPDY}.${scyc}0000.coupler.res ]; then
+  export warm_start=".true."
+fi
+
+# turn IAU off for cold start
+DOIAU_coldstart=${DOIAU_coldstart:-"NO"}
+if [ $DOIAU = "YES" -a $warm_start = ".false." ] || [ $DOIAU_coldstart = "YES" -a $warm_start = ".true." ]; then
+  export DOIAU="NO"
+  echo "turning off IAU"
+  DOIAU_coldstart="YES"
+  IAU_OFFSET=0
+  sCDATE=$CDATE
+  sPDY=$PDY
+  scyc=$cyc
+  tPDY=$sPDY
+  tcyc=$cyc
+fi
+
+#-------------------------------------------------------
+if [ $warm_start = ".true." -o $RERUN = "YES" ]; then
+   CHEMIN=1 #lzhang
+#-------------------------------------------------------
+#.............................
+  if [ $RERUN = "NO" ]; then
+#.............................
+
+  # Link all (except sfc_data) restart files from $gmemdir
+    for file in $(ls $gmemdir/RESTART/${sPDY}.${scyc}0000.*.nc); do
+      file2=$(echo $(basename $file))
+      file2=$(echo $file2 | cut -d. -f3-) # remove the date from file
+      fsuf=$(echo $file2 | cut -d. -f1)
+      if [ $fsuf != "sfc_data" ]; then
+         $NLN $file $DATA/INPUT/$file2
+      fi
+    done
+
+  # Link sfcanl_data restart files from $memdir
+    #for file in $(ls $memdir/RESTART/${sPDY}.${scyc}0000.*.nc); do   #lzhang
+    for file in $memdir/RESTART/${sPDY}.${scyc}0000.*.nc; do
+      file2=$(echo $(basename $file))
+      file2=$(echo $file2 | cut -d. -f3-) # remove the date from file
+      fsufanl=$(echo $file2 | cut -d. -f1)
+      if [ $fsufanl = "sfcanl_data" ]; then
+        file2=$(echo $file2 | sed -e "s/sfcanl_data/sfc_data/g")
+        $NLN $file $DATA/INPUT/$file2
+      fi
+    done
+#lzhang cp atminc.nc to output dir
+   cd $DATA
+   $NCP ../calcinc/atminc.nc $memdir/${CDUMP}.t${cyc}z.atminc.nc
+
+
+  # Need a coupler.res when doing IAU
+    if [ $DOIAU = "YES" ]; then
+      rm -f $DATA/INPUT/coupler.res
+      cat >> $DATA/INPUT/coupler.res << EOF
+     2        (Calendar: no_calendar=0, thirty_day_months=1, julian=2, gregorian=3, noleap=4)
+  ${gPDY:0:4}  ${gPDY:4:2}  ${gPDY:6:2}  ${gcyc}     0     0        Model start time:   year, month, day, hour, minute, second
+  ${sPDY:0:4}  ${sPDY:4:2}  ${sPDY:6:2}  ${scyc}     0     0        Current model time: year, month, day, hour, minute, second
+EOF
+    fi
+
+  # Link increments
+    if [ $DOIAU = "YES" ]; then
+      for i in $(echo $IAUFHRS | sed "s/,/ /g" | rev); do
+        incfhr=$(printf %03i $i)
+        if [ $incfhr = "006" ]; then
+          increment_file=$memdir/${CDUMP}.t${cyc}z.${PREFIX_ATMINC}atminc.nc
+        else
+          increment_file=$memdir/${CDUMP}.t${cyc}z.${PREFIX_ATMINC}atmi${incfhr}.nc
+        fi
+        if [ ! -f $increment_file ]; then
+          echo "ERROR: DOIAU = $DOIAU, but missing increment file for fhr $incfhr at $increment_file"
+          echo "Abort!"
+          exit 1
+        fi
+        $NLN $increment_file $DATA/INPUT/fv_increment$i.nc
+        IAU_INC_FILES="'fv_increment$i.nc',$IAU_INC_FILES"
+      done
+      read_increment=".false."
+      res_latlon_dynamics=""
+    else
+      increment_file=$memdir/${CDUMP}.t${cyc}z.${PREFIX_INC}atminc.nc
+      if [ -f $increment_file ]; then
+        $NLN $increment_file $DATA/INPUT/fv_increment.nc
+        read_increment=".true."
+        res_latlon_dynamics="fv_increment.nc"
+      fi
+    fi
+#lzhang: link sfc data from gfs initial conditions
+  for file in $memdir/INPUT/*.nc; do
+    file2=$(echo $(basename $file))
+    fsuf=$(echo $file2 | cut -c1-3)
+    if [ $fsuf = "sfc" ]; then
+      $NLN $file $DATA/INPUT/$file2
+    fi
+  done
+#lzhang
+#.............................
+  else  ##RERUN                         
+
+    export warm_start=".true."
+    PDYT=$(echo $CDATE_RST | cut -c1-8)
+    cyct=$(echo $CDATE_RST | cut -c9-10)
+    for file in $(ls $RSTDIR_ATM/${PDYT}.${cyct}0000.*); do
+      file2=$(echo $(basename $file))
+      file2=$(echo $file2 | cut -d. -f3-) 
+      $NLN $file $DATA/INPUT/$file2
+    done
+   
+    hour_rst=`$NHOUR $CDATE_RST $CDATE`
+    IAU_FHROT=$((IAU_OFFSET+hour_rst))         
+    if [ $DOIAU = "YES" ]; then
+      IAUFHRS=-1         
+      IAU_DELTHRS=0
+      IAU_INC_FILES="''"
+    fi
+
+
+  fi
+#.............................
+
+else ## cold start                            
+  CHEMIN=0 #lzhang
+
+  for file in $(ls $memdir/INPUT/*.nc); do
+    file2=$(echo $(basename $file))
+    fsuf=$(echo $file2 | cut -c1-3)
+    if [ $fsuf = "gfs" -o $fsuf = "sfc" ]; then
+      $NLN $file $DATA/INPUT/$file2
+    fi
+  done
+
+#-------------------------------------------------------
+fi 
+#-------------------------------------------------------
+
+nfiles=$(ls -1 $DATA/INPUT/* | wc -l)
+if [ $nfiles -le 0 ]; then
+  echo "Initial conditions must exist in $DATA/INPUT, ABORT!"
+  msg="Initial conditions must exist in $DATA/INPUT, ABORT!"
+  postmsg "$jlogfile" "$msg"
+  exit 1
+fi
+
+# If doing IAU, change forecast hours
+if [[ "$DOIAU" = "YES" ]]; then
+  FHMAX=$((FHMAX+6))
+  if [ $FHMAX_HF -gt 0 ]; then
+     FHMAX_HF=$((FHMAX_HF+6))
+  fi
+fi
+
+#--------------------------------------------------------------------------
+# Grid and orography data
+for n in $(seq 1 $ntiles); do
+  $NLN $FIXfv3/$CASE/${CASE}_grid.tile${n}.nc     $DATA/INPUT/${CASE}_grid.tile${n}.nc
+  $NLN $FIXfv3/$CASE/${CASE}_oro_data.tile${n}.nc $DATA/INPUT/oro_data.tile${n}.nc
+done
+$NLN $FIXfv3/$CASE/${CASE}_mosaic.nc  $DATA/INPUT/grid_spec.nc
+
+# GFS standard input data
+IAER=${IAER:-111}
+ICO2=${ICO2:-2}
+
+if [ ${new_o3forc:-YES} = YES ]; then
+    O3FORC=ozprdlos_2015_new_sbuvO3_tclm15_nuchem.f77
+else
+    O3FORC=global_o3prdlos.f77
+fi
+H2OFORC=${H2OFORC:-"global_h2o_pltc.f77"}
+$NLN $FIX_AM/${O3FORC}                         $DATA/global_o3prdlos.f77
+$NLN $FIX_AM/${H2OFORC}                        $DATA/global_h2oprdlos.f77
+$NLN $FIX_AM/global_solarconstant_noaa_an.txt  $DATA/solarconstant_noaa_an.txt
+$NLN $FIX_AM/global_sfc_emissivity_idx.txt     $DATA/sfc_emissivity_idx.txt
+
+$NLN $FIX_AM/global_co2historicaldata_glob.txt $DATA/co2historicaldata_glob.txt
+$NLN $FIX_AM/co2monthlycyc.txt                 $DATA/co2monthlycyc.txt
+if [ $ICO2 -gt 0 ]; then
+  for file in $(ls $FIX_AM/fix_co2_proj/global_co2historicaldata*) ; do
+    $NLN $file $DATA/$(echo $(basename $file) | sed -e "s/global_//g")
+  done
+fi
+
+$NLN $FIX_AM/global_climaeropac_global.txt     $DATA/aerosol.dat
+if [ $IAER -gt 0 ] ; then
+  for file in $(ls $FIX_AM/global_volcanic_aerosols*) ; do
+    $NLN $file $DATA/$(echo $(basename $file) | sed -e "s/global_//g")
+  done
+fi
+
+#-------------wavewave----------------------
+if [ $cplwav = ".true." ]; then
+#-------------wavewave----------------------
+
+  for file in $(ls $ROTDIR/${CDUMP}wave.${PDY}/${cyc}/rundata/rmp_src_to_dst_conserv_*) ; do
+    $NLN $file $DATA/
+  done
+  $NLN $ROTDIR/${CDUMP}wave.${PDY}/${cyc}/rundata/ww3_multi.${CDUMP}wave${WAV_MEMBER}.${cycle}.inp $DATA/ww3_multi.inp
+
+  array=($WAVECUR_FID $WAVEICE_FID $WAVEWND_FID $waveuoutpGRD $waveGRD $waveesmfGRD $wavesbsGRD $wavepostGRD $waveinterpGRD)
+  grdALL=`printf "%s\n" "${array[@]}" | sort -u | tr '\n' ' '`
+  for wavGRD in ${grdALL}; do
+    $NLN $ROTDIR/${CDUMP}wave.${PDY}/${cyc}/rundata/${CDUMP}wave.mod_def.$wavGRD $DATA/mod_def.$wavGRD
+  done
+
+  WAVHCYC=${WAVHCYC:-6}
+  WRDATE=`$NDATE -${WAVHCYC} $CDATE`
+  WRPDY=`echo $WRDATE | cut -c1-8`
+  WRcyc=`echo $WRDATE | cut -c9-10`
+  WRDIR=$ROTDIR/gdaswave.${WRPDY}/${WRcyc}/restart
+  datwave=$ROTDIR/${CDUMP}wave.${PDY}/${cyc}/rundata/
+  wavprfx=${CDUMP}wave${WAV_MEMBER}
+
+  for wavGRD in $waveGRD ; do
+    if [ $RERUN = "NO" ]; then
+      $NLN ${WRDIR}/${sPDY}.${scyc}0000.restart.${wavGRD} $DATA/restart.${wavGRD}
+    else
+      $NLN ${RSTDIR_WAVE}/${PDYT}.${cyct}0000.restart.${wavGRD} $DATA/restart.${wavGRD}
+    fi
+    eval $NLN $datwave/${wavprfx}.log.${wavGRD}.${PDY}${cyc} log.${wavGRD}
+  done
+
+  if [ "$WW3ICEINP" = "YES" ]; then
+    wavicefile=$ROTDIR/${CDUMP}wave.${PDY}/${cyc}/rundata/${CDUMP}wave.${WAVEICE_FID}.${cycle}.ice
+    if [ ! -f $wavicefile ]; then
+      echo "ERROR: WW3ICEINP = ${WW3ICEINP}, but missing ice file"
+      echo "Abort!"
+      exit 1
+    fi
+    $NLN ${wavicefile} $DATA/ice.${WAVEICE_FID}
+  fi
+
+  if [ "$WW3CURINP" = "YES" ]; then
+    wavcurfile=$ROTDIR/${CDUMP}wave.${PDY}/${cyc}/rundata/${CDUMP}wave.${WAVECUR_FID}.${cycle}.cur
+    if [ ! -f $wavcurfile ]; then
+      echo "ERROR: WW3CURINP = ${WW3CURINP}, but missing current file"
+      echo "Abort!"
+      exit 1
+    fi
+    $NLN $wavcurfile $DATA/current.${WAVECUR_FID}
+  fi
+
+  # Link output files
+  cd $DATA
+  eval $NLN $datwave/${wavprfx}.log.mww3.${PDY}${cyc} log.mww3
+  fhr=$FHMIN_WAV
+  while [ $fhr -le $FHMAX_WAV ]; do
+    YMDH=`$NDATE $fhr $CDATE`
+    YMD=$(echo $YMDH | cut -c1-8)
+    HMS="$(echo $YMDH | cut -c9-10)0000"
+      for wavGRD in ${waveGRD} ; do
+        eval $NLN $datwave/${wavprfx}.out_grd.${wavGRD}.${YMD}.${HMS} ${YMD}.${HMS}.out_grd.${wavGRD}
+      done
+      FHINC=$FHOUT_WAV
+      if [ $FHMAX_HF_WAV -gt 0 -a $FHOUT_HF_WAV -gt 0 -a $fhr -lt $FHMAX_HF_WAV ]; then
+        FHINC=$FHOUT_HF_WAV
+      fi
+    fhr=$((fhr+FHINC))
+  done
+
+  # Loop for point output (uses DTPNT)
+  fhr=$FHMIN_WAV
+  while [ $fhr -le $FHMAX_WAV ]; do
+    YMDH=`$NDATE $fhr $CDATE`
+    YMD=$(echo $YMDH | cut -c1-8)
+    HMS="$(echo $YMDH | cut -c9-10)0000"
+      eval $NLN $datwave/${wavprfx}.out_pnt.${waveuoutpGRD}.${YMD}.${HMS} ${YMD}.${HMS}.out_pnt.${waveuoutpGRD}
+      FHINC=$FHINCP_WAV
+    fhr=$((fhr+FHINC))
+  done
+
+#-------------wavewave----------------------
+fi
+#-------------wavewave----------------------
+
+
+# inline post fix files
+if [ $WRITE_DOPOST = ".true." ]; then
+    $NLN $PARM_POST/post_tag_gfs${LEVS}             $DATA/itag               
+    $NLN $PARM_POST/postxconfig-NT-GFS-TWO.txt      $DATA/postxconfig-NT.txt 
+    $NLN $PARM_POST/postxconfig-NT-GFS-F00-TWO.txt  $DATA/postxconfig-NT_FH00.txt
+    $NLN $PARM_POST/params_grib2_tbl_new            $DATA/params_grib2_tbl_new
+fi
+#------------------------------------------------------------------
+#------------------------------------------------------------------
+# changeable parameters
+# dycore definitions
+res=$(echo $CASE |cut -c2-5)
+resp=$((res+1))
+npx=$resp
+npy=$resp
+npz=$((LEVS-1))
+io_layout=${io_layout:-"1,1"}
+#ncols=$(( (${npx}-1)*(${npy}-1)*3/2 ))
+
+# spectral truncation and regular grid resolution based on FV3 resolution
+JCAP_CASE=$((2*res-2))
+LONB_CASE=$((4*res))
+LATB_CASE=$((2*res))
+
+JCAP=${JCAP:-$JCAP_CASE}
+LONB=${LONB:-$LONB_CASE}
+LATB=${LATB:-$LATB_CASE}
+
+LONB_IMO=${LONB_IMO:-$LONB_CASE}
+LATB_JMO=${LATB_JMO:-$LATB_CASE}
+
+# Fix files
+FNGLAC=${FNGLAC:-"$FIX_AM/global_glacier.2x2.grb"}
+FNMXIC=${FNMXIC:-"$FIX_AM/global_maxice.2x2.grb"}
+FNTSFC=${FNTSFC:-"$FIX_AM/RTGSST.1982.2012.monthly.clim.grb"}
+FNSNOC=${FNSNOC:-"$FIX_AM/global_snoclim.1.875.grb"}
+FNZORC=${FNZORC:-"igbp"}
+FNALBC2=${FNALBC2:-"$FIX_AM/global_albedo4.1x1.grb"}
+FNAISC=${FNAISC:-"$FIX_AM/CFSR.SEAICE.1982.2012.monthly.clim.grb"}
+FNTG3C=${FNTG3C:-"$FIX_AM/global_tg3clim.2.6x1.5.grb"}
+FNVEGC=${FNVEGC:-"$FIX_AM/global_vegfrac.0.144.decpercent.grb"}
+FNMSKH=${FNMSKH:-"$FIX_AM/global_slmask.t1534.3072.1536.grb"}
+FNVMNC=${FNVMNC:-"$FIX_AM/global_shdmin.0.144x0.144.grb"}
+FNVMXC=${FNVMXC:-"$FIX_AM/global_shdmax.0.144x0.144.grb"}
+FNSLPC=${FNSLPC:-"$FIX_AM/global_slope.1x1.grb"}
+FNALBC=${FNALBC:-"$FIX_AM/global_snowfree_albedo.bosu.t${JCAP}.${LONB}.${LATB}.rg.grb"}
+FNVETC=${FNVETC:-"$FIX_AM/global_vegtype.igbp.t${JCAP}.${LONB}.${LATB}.rg.grb"}
+FNSOTC=${FNSOTC:-"$FIX_AM/global_soiltype.statsgo.t${JCAP}.${LONB}.${LATB}.rg.grb"}
+FNABSC=${FNABSC:-"$FIX_AM/global_mxsnoalb.uariz.t${JCAP}.${LONB}.${LATB}.rg.grb"}
+FNSMCC=${FNSMCC:-"$FIX_AM/global_soilmgldas.statsgo.t${JCAP}.${LONB}.${LATB}.grb"}
+
+# If the appropriate resolution fix file is not present, use the highest resolution available (T1534)
+[[ ! -f $FNALBC ]] && FNALBC="$FIX_AM/global_snowfree_albedo.bosu.t1534.3072.1536.rg.grb"
+[[ ! -f $FNVETC ]] && FNVETC="$FIX_AM/global_vegtype.igbp.t1534.3072.1536.rg.grb"
+[[ ! -f $FNSOTC ]] && FNSOTC="$FIX_AM/global_soiltype.statsgo.t1534.3072.1536.rg.grb"
+[[ ! -f $FNABSC ]] && FNABSC="$FIX_AM/global_mxsnoalb.uariz.t1534.3072.1536.rg.grb"
+[[ ! -f $FNSMCC ]] && FNSMCC="$FIX_AM/global_soilmgldas.statsgo.t1534.3072.1536.grb"
+
+# NSST Options
+# nstf_name contains the NSST related parameters
+# nstf_name(1) : NST_MODEL (NSST Model) : 0 = OFF, 1 = ON but uncoupled, 2 = ON and coupled
+# nstf_name(2) : NST_SPINUP : 0 = OFF, 1 = ON,
+# nstf_name(3) : NST_RESV (Reserved, NSST Analysis) : 0 = OFF, 1 = ON
+# nstf_name(4) : ZSEA1 (in mm) : 0
+# nstf_name(5) : ZSEA2 (in mm) : 0
+# nst_anl      : .true. or .false., NSST analysis over lake
+NST_MODEL=${NST_MODEL:-0}
+NST_SPINUP=${NST_SPINUP:-0}
+NST_RESV=${NST_RESV-0}
+ZSEA1=${ZSEA1:-0}
+ZSEA2=${ZSEA2:-0}
+nstf_name=${nstf_name:-"$NST_MODEL,$NST_SPINUP,$NST_RESV,$ZSEA1,$ZSEA2"}
+nst_anl=${nst_anl:-".false."}
+
+
+# blocking factor used for threading and general physics performance
+#nyblocks=`expr \( $npy - 1 \) \/ $layout_y `
+#nxblocks=`expr \( $npx - 1 \) \/ $layout_x \/ 32`
+#if [ $nxblocks -le 0 ]; then nxblocks=1 ; fi
+blocksize=${blocksize:-32}
+
+# the pre-conditioning of the solution
+# =0 implies no pre-conditioning
+# >0 means new adiabatic pre-conditioning
+# <0 means older adiabatic pre-conditioning
+na_init=${na_init:-1}
+[[ $warm_start = ".true." ]] && na_init=0
+
+# variables for controlling initialization of NCEP/NGGPS ICs
+filtered_terrain=${filtered_terrain:-".true."}
+gfs_dwinds=${gfs_dwinds:-".true."}
+
+# various debug options
+no_dycore=${no_dycore:-".false."}
+dycore_only=${adiabatic:-".false."}
+chksum_debug=${chksum_debug:-".false."}
+print_freq=${print_freq:-6}
+
+if [ ${TYPE} = "nh" ]; then # non-hydrostatic options
+
+  hydrostatic=".false."
+  phys_hydrostatic=".false."     # enable heating in hydrostatic balance in non-hydrostatic simulation
+  use_hydro_pressure=".false."   # use hydrostatic pressure for physics
+  if [ $warm_start = ".true." ]; then
+    make_nh=".false."              # restarts contain non-hydrostatic state
+  else
+    make_nh=".true."               # re-initialize non-hydrostatic state
+  fi
+
+else # hydrostatic options
+
+  hydrostatic=".true."
+  phys_hydrostatic=".false."     # ignored when hydrostatic = T
+  use_hydro_pressure=".false."   # ignored when hydrostatic = T
+  make_nh=".false."              # running in hydrostatic mode
+
+fi
+
+# Conserve total energy as heat globally
+consv_te=${consv_te:-1.} # range 0.-1., 1. will restore energy to orig. val. before physics
+
+# time step parameters in FV3
+k_split=${k_split:-2}
+n_split=${n_split:-6}
+
+if [ $(echo $MONO | cut -c-4) = "mono" ];  then # monotonic options
+
+  d_con=${d_con_mono:-"0."}
+  do_vort_damp=".false."
+  if [ ${TYPE} = "nh" ]; then # non-hydrostatic
+    hord_mt=${hord_mt_nh_mono:-"10"}
+    hord_xx=${hord_xx_nh_mono:-"10"}
+  else # hydrostatic
+    hord_mt=${hord_mt_hydro_mono:-"10"}
+    hord_xx=${hord_xx_hydro_mono:-"10"}
+  fi
+
+else # non-monotonic options
+
+  d_con=${d_con_nonmono:-"1."}
+  do_vort_damp=".true."
+  if [ ${TYPE} = "nh" ]; then # non-hydrostatic
+    hord_mt=${hord_mt_nh_nonmono:-"5"}
+    hord_xx=${hord_xx_nh_nonmono:-"5"}
+  else # hydrostatic
+    hord_mt=${hord_mt_hydro_nonmono:-"10"}
+    hord_xx=${hord_xx_hydro_nonmono:-"10"}
+  fi
+
+fi
+
+if [ $(echo $MONO | cut -c-4) != "mono" -a $TYPE = "nh" ]; then
+  vtdm4=${vtdm4_nh_nonmono:-"0.06"}
+else
+  vtdm4=${vtdm4:-"0.05"}
+fi
+
+if [ $warm_start = ".true." ]; then # warm start from restart file
+
+  nggps_ic=".false."
+  ncep_ic=".false."
+  external_ic=".false."
+  mountain=".true."
+  if [ $read_increment = ".true." ]; then # add increment on the fly to the restarts
+    res_latlon_dynamics="fv_increment.nc"
+  else
+    res_latlon_dynamics='""'
+  fi
+
+else # CHGRES'd GFS analyses
+
+  nggps_ic=${nggps_ic:-".true."}
+  ncep_ic=${ncep_ic:-".false."}
+  external_ic=".true."
+  mountain=".false."
+  read_increment=".false."
+  res_latlon_dynamics='""'
+
+fi
+
+# Stochastic Physics Options
+if [ ${SET_STP_SEED:-"YES"} = "YES" ]; then
+  ISEED_SKEB=$((CDATE*1000 + MEMBER*10 + 1))
+  ISEED_SHUM=$((CDATE*1000 + MEMBER*10 + 2))
+  ISEED_SPPT=$((CDATE*1000 + MEMBER*10 + 3))
+else
+  ISEED=${ISEED:-0}
+fi
+DO_SKEB=${DO_SKEB:-"NO"}
+DO_SPPT=${DO_SPPT:-"NO"}
+DO_SHUM=${DO_SHUM:-"NO"}
+
+if [ $DO_SKEB = "YES" ]; then
+    do_skeb=".true."
+fi
+if [ $DO_SHUM = "YES" ]; then
+    do_shum=".true."
+fi
+if [ $DO_SPPT = "YES" ]; then
+    do_sppt=".true."
+fi
+
+# copy over the tables
+DIAG_TABLE=${DIAG_TABLE:-$PARM_FV3DIAG/diag_table}
+DATA_TABLE=${DATA_TABLE:-$PARM_FV3DIAG/data_table}
+FIELD_TABLE=${FIELD_TABLE:-$PARM_FV3DIAG/field_table}
+
+# build the diag_table with the experiment name and date stamp
+if [ $DOIAU = "YES" ]; then
+cat > diag_table << EOF
+FV3 Forecast
+${gPDY:0:4} ${gPDY:4:2} ${gPDY:6:2} ${gcyc} 0 0
+EOF
+cat $DIAG_TABLE >> diag_table
+else
+cat > diag_table << EOF
+FV3 Forecast
+${sPDY:0:4} ${sPDY:4:2} ${sPDY:6:2} ${scyc} 0 0
+EOF
+cat $DIAG_TABLE >> diag_table
+fi
+
+$NCP $DATA_TABLE  data_table
+$NCP $FIELD_TABLE field_table
+
+# copy CCN_ACTIVATE.BIN for Thompson microphysics
+if [ $imp_physics -eq 8 ]; then 
+  $NLN $FIX_AM/CCN_ACTIVATE.BIN  CCN_ACTIVATE.BIN
+  $NLN $FIX_AM/freezeH2O.dat  freezeH2O.dat
+  $NLN $FIX_AM/qr_acr_qg.dat  qr_acr_qg.dat
+  $NLN $FIX_AM/qr_acr_qs.dat  qr_acr_qs.dat
+fi
+
+#------------------------------------------------------------------
+rm -f nems.configure
+
+if [ $cplwav = ".true." ]; then
+#### ww3 version of nems.configure
+
+# Switch on cpl flag
+  cpl=.true.
+
+NTASKS_FV3m1=$((NTASKS_FV3-1))
+atm_petlist_bounds=" 0 $((NTASKS_FV3-1))"
+wav_petlist_bounds=" $((NTASKS_FV3)) $((NTASKS_FV3m1+npe_wav))"
+###  atm_petlist_bounds=" 0   1511"
+###  atm_petlist_bounds=$atm_petlist_bounds
+###  wav_petlist_bounds="1512 1691"
+###  wav_petlist_bounds=$wav_petlist_bounds
+  coupling_interval_sec=${coupling_interval_sec:-1800}
+  rm -f nems.configure
+cat > nems.configure <<EOF
+EARTH_component_list: ATM WAV
+EARTH_attributes::
+  Verbosity = high
+  HierarchyProtocol = off
+::
+
+ATM_model:                      fv3
+ATM_petlist_bounds:             ${atm_petlist_bounds}
+ATM_attributes::
+  Verbosity = 0
+  DumpFields = false
+::
+
+WAV_model:                      ww3
+WAV_petlist_bounds:             ${wav_petlist_bounds}
+WAV_attributes::
+  Verbosity = high
+::
+
+runSeq::
+  @${coupling_interval_sec}
+    ATM
+    ATM -> WAV :SrcTermProcessing=0:TermOrder=SrcSeq
+    WAV
+  @
+::
+EOF
+else
+#### fv3 standalone version of nems.configure
+cat > nems.configure <<EOF
+EARTH_component_list: ATM
+ATM_model:            fv3
+runSeq::
+  ATM
+::
+EOF
+fi
+
+# Set NTASKS_CFG to reflect cplwav
+NTASKS_CFG=$NTASKS_FV3
+if [ $cplwav = ".true." ]; then
+  NTASKS_CFG=$((NTASKS_FV3 + npe_wav))
+fi
+
+rm -f model_configure
+cat > model_configure <<EOF
+total_member:            $ENS_NUM
+print_esmf:              ${print_esmf:-.false.}
+PE_MEMBER01:             $NTASKS_CFG
+start_year:              ${tPDY:0:4}
+start_month:             ${tPDY:4:2}
+start_day:               ${tPDY:6:2}
+start_hour:              ${tcyc}
+start_minute:            0
+start_second:            0
+fhrot:                   ${IAU_FHROT:-0}
+nhours_fcst:             $FHMAX
+RUN_CONTINUE:            ${RUN_CONTINUE:-".false."}
+ENS_SPS:                 ${ENS_SPS:-".false."}
+
+dt_atmos:                $DELTIM
+output_1st_tstep_rst:    .false.
+calendar:                ${calendar:-'julian'}
+cpl:                     ${cpl:-".false."}
+memuse_verbose:          ${memuse_verbose:-".false."}
+atmos_nthreads:          $NTHREADS_FV3
+use_hyper_thread:        ${hyperthread:-".false."}
+ncores_per_node:         $cores_per_node
+restart_interval:        $restart_interval
+
+quilting:                $QUILTING
+write_groups:            ${WRITE_GROUP:-1}
+write_tasks_per_group:   ${WRTTASK_PER_GROUP:-24}
+output_history:          ${OUTPUT_HISTORY:-".true."}
+write_dopost:            ${WRITE_DOPOST:-".false."}
+num_files:               ${NUM_FILES:-2}
+filename_base:           'atm' 'sfc'
+output_grid:             $OUTPUT_GRID
+output_file:             $OUTPUT_FILETYPES
+ichunk2d:                ${ichunk2d:-0}
+jchunk2d:                ${jchunk2d:-0}
+ichunk3d:                ${ichunk3d:-0}
+jchunk3d:                ${jchunk3d:-0}
+kchunk3d:                ${kchunk3d:-0}
+ideflate:                ${ideflate:-1}
+nbits:                   ${nbits:-14}
+write_nemsioflip:        $WRITE_NEMSIOFLIP
+write_fsyncflag:         $WRITE_FSYNCFLAG
+imo:                     $LONB_IMO
+jmo:                     $LATB_JMO
+
+nfhout:                  $FHOUT
+nfhmax_hf:               $FHMAX_HF
+nfhout_hf:               $FHOUT_HF
+nsout:                   $NSOUT
+iau_offset:              ${IAU_OFFSET}
+EOF
+
+#&coupler_nml
+#  months = ${months:-0}
+#  days = ${days:-$((FHMAX/24))}
+#  hours = ${hours:-$((FHMAX-24*(FHMAX/24)))}
+#  dt_atmos = $DELTIM
+#  dt_ocean = $DELTIM
+#  current_date = $curr_date
+#  calendar = 'julian'
+#  memuse_verbose = .false.
+#  atmos_nthreads = $NTHREADS_FV3
+#  use_hyper_thread = ${hyperthread:-".false."}
+#  ncores_per_node = $cores_per_node
+#  restart_secs = $restart_secs
+#  $coupler_nml
+#/
+
+cat > input.nml <<EOF
+&amip_interp_nml
+  interp_oi_sst = .true.
+  use_ncep_sst = .true.
+  use_ncep_ice = .false.
+  no_anom_sst = .false.
+  data_set = 'reynolds_oi'
+  date_out_of_range = 'climo'
+  $amip_interp_nml
+/
+
+&atmos_model_nml
+  blocksize = $blocksize
+  chksum_debug = $chksum_debug
+  dycore_only = $dycore_only
+  ccpp_suite = $CCPP_SUITE
+  fdiag = $FDIAG
+  fhmax = $FHMAX
+  fhout = $FHOUT
+  fhmaxhf = $FHMAX_HF
+  fhouthf = $FHOUT_HF
+  $atmos_model_nml
+/
+
+&diag_manager_nml
+  prepend_date = .false.
+  $diag_manager_nml
+/
+
+&fms_io_nml
+  checksum_required = .false.
+  max_files_r = 100
+  max_files_w = 100
+  $fms_io_nml
+/
+
+&mpp_io_nml
+shuffle=${shuffle:-1}
+deflate_level=${deflate_level:-1}
+/
+
+&fms_nml
+  clock_grain = 'ROUTINE'
+  domains_stack_size = ${domains_stack_size:-3000000}
+  print_memory_usage = ${print_memory_usage:-".false."}
+  $fms_nml
+/
+
+&fv_core_nml
+  layout = $layout_x,$layout_y
+  io_layout = $io_layout
+  npx = $npx
+  npy = $npy
+  ntiles = $ntiles
+  npz = $npz
+  grid_type = -1
+  make_nh = $make_nh
+  fv_debug = ${fv_debug:-".false."}
+  range_warn = ${range_warn:-".false."}
+  reset_eta = .false.
+  n_sponge = ${n_sponge:-"10"}
+  nudge_qv = ${nudge_qv:-".true."}
+  nudge_dz = ${nudge_dz:-".false."}
+  tau = ${tau:-10.}
+  rf_cutoff = ${rf_cutoff:-"7.5e2"}
+  d2_bg_k1 = ${d2_bg_k1:-"0.15"}
+  d2_bg_k2 = ${d2_bg_k2:-"0.02"}
+  kord_tm = ${kord_tm:-"-9"}
+  kord_mt = ${kord_mt:-"9"}
+  kord_wz = ${kord_wz:-"9"}
+  kord_tr = ${kord_tr:-"9"}
+  hydrostatic = $hydrostatic
+  phys_hydrostatic = $phys_hydrostatic
+  use_hydro_pressure = $use_hydro_pressure
+  beta = 0.
+  a_imp = 1.
+  p_fac = 0.1
+  k_split = $k_split
+  n_split = $n_split
+  nwat = ${nwat:-2}
+  na_init = $na_init
+  d_ext = 0.
+  dnats = ${dnats:-0}
+  fv_sg_adj = ${fv_sg_adj:-"450"}
+  d2_bg = 0.
+  nord = ${nord:-3}
+  dddmp = ${dddmp:-0.2}
+  d4_bg = ${d4_bg:-0.15}
+  vtdm4 = $vtdm4
+  delt_max = ${delt_max:-"0.002"}
+  ke_bg = 0.
+  do_vort_damp = $do_vort_damp
+  external_ic = $external_ic
+  external_eta = ${external_eta:-.true.}
+  gfs_phil = ${gfs_phil:-".false."}
+  nggps_ic = $nggps_ic
+  mountain = $mountain
+  ncep_ic = $ncep_ic
+  d_con = $d_con
+  hord_mt = $hord_mt
+  hord_vt = $hord_xx
+  hord_tm = $hord_xx
+  hord_dp = -$hord_xx
+  hord_tr = ${hord_tr:-"8"}
+  adjust_dry_mass = ${adjust_dry_mass:-".true."}
+  dry_mass=${dry_mass:-98320.0}
+  consv_te = $consv_te
+  do_sat_adj = ${do_sat_adj:-".false."}
+  consv_am = .false.
+  fill = .true.
+  dwind_2d = .false.
+  print_freq = $print_freq
+  warm_start = $warm_start
+  no_dycore = $no_dycore
+  z_tracer = .true.
+  agrid_vel_rst = ${agrid_vel_rst:-".true."}
+  read_increment = $read_increment
+  res_latlon_dynamics = $res_latlon_dynamics
+  $fv_core_nml
+/
+
+&cires_ugwp_nml
+       knob_ugwp_solver  = ${knob_ugwp_solver:-2}
+       knob_ugwp_source  = ${knob_ugwp_source:-1,1,0,0}
+       knob_ugwp_wvspec  = ${knob_ugwp_wvspec:-1,25,25,25}
+       knob_ugwp_azdir   = ${knob_ugwp_azdir:-2,4,4,4}
+       knob_ugwp_stoch   = ${knob_ugwp_stoch:-0,0,0,0}
+       knob_ugwp_effac   = ${knob_ugwp_effac:-1,1,1,1}
+       knob_ugwp_doaxyz  = ${knob_ugwp_doaxyz:-1}
+       knob_ugwp_doheat  = ${knob_ugwp_doheat:-1}
+       knob_ugwp_dokdis  = ${knob_ugwp_dokdis:-1}
+       knob_ugwp_ndx4lh  = ${knob_ugwp_ndx4lh:-1}
+       knob_ugwp_version = ${knob_ugwp_version:-0}
+       launch_level      = ${launch_level:-54}                   
+/
+
+&external_ic_nml
+  filtered_terrain = $filtered_terrain
+  levp = $LEVS
+  gfs_dwinds = $gfs_dwinds
+  checker_tr = .false.
+  nt_checker = 0
+  $external_ic_nml
+/
+
+&gfs_physics_nml
+  fhzero       = $FHZER
+  h2o_phys     = ${h2o_phys:-".true."}
+  ldiag3d      = ${ldiag3d:-".false."}
+  fhcyc        = $FHCYC
+  use_ufo      = ${use_ufo:-".true."}
+  pre_rad      = ${pre_rad:-".false."}
+  ncld         = ${ncld:-1}
+  imp_physics  = ${imp_physics:-"99"}
+  ltaerosol    = ${ltaerosol:-".F."}
+  lradar       = ${lradar:-".F."}
+  pdfcld       = ${pdfcld:-".false."}
+  fhswr        = ${FHSWR:-"3600."}
+  fhlwr        = ${FHLWR:-"3600."}
+  ialb         = ${IALB:-"1"}
+  iems         = ${IEMS:-"1"}
+  iaer         = $IAER
+  icliq_sw     = ${icliq_sw:-"2"}
+  iovr_lw      = ${iovr_lw:-"3"}
+  iovr_sw      = ${iovr_sw:-"3"}
+  ico2         = $ICO2
+  isubc_sw     = ${isubc_sw:-"2"}
+  isubc_lw     = ${isubc_lw:-"2"}
+  isol         = ${ISOL:-"2"}
+  lwhtr        = ${lwhtr:-".true."}
+  swhtr        = ${swhtr:-".true."}
+  cnvgwd       = ${cnvgwd:-".true."}
+  shal_cnv     = ${shal_cnv:-".true."}
+  cal_pre      = ${cal_pre:-".true."}
+  redrag       = ${redrag:-".true."}
+  dspheat      = ${dspheat:-".true."}
+  hybedmf      = ${hybedmf:-".true."}
+  satmedmf     = ${satmedmf-".false."}
+  isatmedmf    = ${isatmedmf-"1"}
+  lheatstrg    = ${lheatstrg-".true."}
+  do_mynnedmf  = ${do_mynnedmf:-".false."}
+  do_mynnsfclay= ${do_mynnsfclay:-".false."}
+  random_clds  = ${random_clds:-".true."}
+  trans_trac   = ${trans_trac:-".true."}
+  cnvcld       = ${cnvcld:-".true."}
+  ttendlim     = ${ttendlim:-"0.005"}
+  imfshalcnv   = ${imfshalcnv:-"2"}
+  imfdeepcnv   = ${imfdeepcnv:-"2"}
+  cdmbgwd      = ${cdmbgwd:-"3.5,0.25"}
+  prslrd0      = ${prslrd0:-"0."}
+  ivegsrc      = ${ivegsrc:-"1"}
+  isot         = ${isot:-"1"}
+  lsoil        = ${lsoil:-"4"}
+  lsm          = ${lsm:-"2"}
+  lsoil_lsm    = ${lsoil_lsm:-"4"}
+  iopt_dveg    = ${iopt_dveg:-"1"}
+  iopt_crs     = ${iopt_crs:-"1"}
+  iopt_btr     = ${iopt_btr:-"1"}
+  iopt_run     = ${iopt_run:-"1"}
+  iopt_sfc     = ${iopt_sfc:-"1"}
+  iopt_frz     = ${iopt_frz:-"1"}
+  iopt_inf     = ${iopt_inf:-"1"}
+  iopt_rad     = ${iopt_rad:-"1"}
+  iopt_alb     = ${iopt_alb:-"2"}
+  iopt_snf     = ${iopt_snf:-"4"}
+  iopt_tbot    = ${iopt_tbot:-"2"}
+  iopt_stc     = ${iopt_stc:-"1"}
+  debug        = ${gfs_phys_debug:-".false."}
+  oz_phys      = ${oz_phys:-".false."}
+  oz_phys_2015 = ${oz_phys_2015:-".true."}
+  icloud_bl    = ${icloud_bl:-"1"}
+  bl_mynn_edmf = ${bl_mynn_edmf:-"1"}
+  bl_mynn_tkeadvect=${bl_mynn_tkeadvect:-".true."}
+  bl_mynn_edmf_mom=${bl_mynn_edmf_mom:-"1"}
+  nstf_name    = $nstf_name
+  nst_anl      = $nst_anl
+  psautco      = ${psautco:-"0.0008,0.0005"}
+  prautco      = ${prautco:-"0.00015,0.00015"}
+  lgfdlmprad   = ${lgfdlmprad:-".false."}
+  effr_in      = ${effr_in:-".false."}
+  cplwav       = ${cplwav:-".false."}
+  cplchm       = ${cplchm:-".true."}
+  ldiag_ugwp   = ${ldiag_ugwp:-".false."}
+  do_ugwp      = ${do_ugwp:-".true."}
+  do_tofd      = ${do_tofd:-".true."}
+  do_sppt      = ${do_sppt:-".false."}
+  do_shum      = ${do_shum:-".false."}
+  do_skeb      = ${do_skeb:-".false."}
+  fscav_aero   = "sulf:0.2", "bc1:0.2","bc2:0.2","oc1:0.2","oc2:0.2",
+EOF
+
+# Add namelist for IAU
+if [ $DOIAU = "YES" ]; then
+  cat >> input.nml << EOF
+  iaufhrs      = ${IAUFHRS}
+  iau_delthrs  = ${IAU_DELTHRS}
+  iau_inc_files= ${IAU_INC_FILES}
+  iau_drymassfixer = .false.
+EOF
+fi
+
+cat >> input.nml <<EOF
+  $gfs_physics_nml
+/
+EOF
+
+echo "" >> input.nml
+
+cat >> input.nml <<EOF
+&gfdl_cloud_microphysics_nml
+  sedi_transport = .true.
+  do_sedi_heat = .false.
+  rad_snow = .true.
+  rad_graupel = .true.
+  rad_rain = .true.
+  const_vi = .F.
+  const_vs = .F.
+  const_vg = .F.
+  const_vr = .F.
+  vi_max = 1.
+  vs_max = 2.
+  vg_max = 12.
+  vr_max = 12.
+  qi_lim = 1.
+  prog_ccn = .false.
+  do_qa = .true.
+  fast_sat_adj = .true.
+  tau_l2v = 225.
+  tau_v2l = 150.
+  tau_g2v = 900.
+  rthresh = 10.e-6  ! This is a key parameter for cloud water
+  dw_land  = 0.16
+  dw_ocean = 0.10
+  ql_gen = 1.0e-3
+  ql_mlt = 1.0e-3
+  qi0_crt = 8.0E-5
+  qs0_crt = 1.0e-3
+  tau_i2s = 1000.
+  c_psaci = 0.05
+  c_pgacs = 0.01
+  rh_inc = 0.30
+  rh_inr = 0.30
+  rh_ins = 0.30
+  ccn_l = 300.
+  ccn_o = 100.
+  c_paut = 0.5
+  c_cracw = 0.8
+  use_ppm = .false.
+  use_ccn = .true.
+  mono_prof = .true.
+  z_slope_liq  = .true.
+  z_slope_ice  = .true.
+  de_ice = .false.
+  fix_negative = .true.
+  icloud_f = 1
+  mp_time = 150.
+  reiflag = ${reiflag:-"2"}
+
+  $gfdl_cloud_microphysics_nml
+/
+
+&interpolator_nml
+  interp_method = 'conserve_great_circle'
+  $interpolator_nml
+/
+
+&namsfc
+  FNGLAC   = '${FNGLAC}'
+  FNMXIC   = '${FNMXIC}'
+  FNTSFC   = '${FNTSFC}'
+  FNSNOC   = '${FNSNOC}'
+  FNZORC   = '${FNZORC}'
+  FNALBC   = '${FNALBC}'
+  FNALBC2  = '${FNALBC2}'
+  FNAISC   = '${FNAISC}'
+  FNTG3C   = '${FNTG3C}'
+  FNVEGC   = '${FNVEGC}'
+  FNVETC   = '${FNVETC}'
+  FNSOTC   = '${FNSOTC}'
+  FNSMCC   = '${FNSMCC}'
+  FNMSKH   = '${FNMSKH}'
+  FNTSFA   = '${FNTSFA}'
+  FNACNA   = '${FNACNA}'
+  FNSNOA   = '${FNSNOA}'
+  FNVMNC   = '${FNVMNC}'
+  FNVMXC   = '${FNVMXC}'
+  FNSLPC   = '${FNSLPC}'
+  FNABSC   = '${FNABSC}'
+  LDEBUG = ${LDEBUG:-".false."}
+  FSMCL(2) = ${FSMCL2:-99999}
+  FSMCL(3) = ${FSMCL3:-99999}
+  FSMCL(4) = ${FSMCL4:-99999}
+  LANDICE  = ${landice:-".true."}
+  FTSFS = ${FTSFS:-90}
+  FAISL = ${FAISL:-99999}
+  FAISS = ${FAISS:-99999}
+  FSNOL = ${FSNOL:-99999}
+  FSNOS = ${FSNOS:-99999}
+  FSICL = 99999
+  FSICS = 99999
+  FTSFL = 99999
+  FVETL = 99999
+  FSOTL = 99999
+  FvmnL = 99999
+  FvmxL = 99999
+  FSLPL = 99999
+  FABSL = 99999
+  $namsfc_nml
+/
+
+&fv_grid_nml
+  grid_file = 'INPUT/grid_spec.nc'
+  $fv_grid_nml
+/
+EOF
+
+# Add namelist for stochastic physics options
+echo "" >> input.nml
+if [ $MEMBER -gt 0 ]; then
+
+    cat >> input.nml << EOF
+&nam_stochy
+EOF
+
+  if [ $DO_SKEB = "YES" ]; then
+    cat >> input.nml << EOF
+  skeb = $SKEB
+  iseed_skeb = ${ISEED_SKEB:-$ISEED}
+  skeb_tau = ${SKEB_TAU:-"-999."}
+  skeb_lscale = ${SKEB_LSCALE:-"-999."}
+  skebnorm = ${SKEBNORM:-"1"}
+  skeb_npass = ${SKEB_nPASS:-"30"}
+  skeb_vdof = ${SKEB_VDOF:-"5"}
+EOF
+  fi
+
+  if [ $DO_SHUM = "YES" ]; then
+    cat >> input.nml << EOF
+  shum = $SHUM
+  iseed_shum = ${ISEED_SHUM:-$ISEED}
+  shum_tau = ${SHUM_TAU:-"-999."}
+  shum_lscale = ${SHUM_LSCALE:-"-999."}
+EOF
+  fi
+
+  if [ $DO_SPPT = "YES" ]; then
+    cat >> input.nml << EOF
+  sppt = $SPPT
+  iseed_sppt = ${ISEED_SPPT:-$ISEED}
+  sppt_tau = ${SPPT_TAU:-"-999."}
+  sppt_lscale = ${SPPT_LSCALE:-"-999."}
+  sppt_logit = ${SPPT_LOGIT:-".true."}
+  sppt_sfclimit = ${SPPT_SFCLIMIT:-".true."}
+  use_zmtnblck = ${use_zmtnblck:-".true."}
+EOF
+  fi
+
+  cat >> input.nml << EOF
+  $nam_stochy_nml
+/
+EOF
+
+
+    cat >> input.nml << EOF
+&nam_sfcperts
+  $nam_sfcperts_nml
+/
+EOF
+
+else
+
+  cat >> input.nml << EOF
+&nam_stochy
+/
+&nam_sfcperts
+/
+EOF
+
+fi
+
+
+#------------------------------------------------------------------
+# make symbolic links to write forecast files directly in memdir
+cd $DATA
+if [ $QUILTING = ".true." -a $OUTPUT_GRID = "gaussian_grid" ]; then
+  fhr=$FHMIN
+  while [ $fhr -le $FHMAX ]; do
+    FH3=$(printf %03i $fhr)
+    FH2=$(printf %02i $fhr)
+    atmi=atmf${FH3}.$affix
+    sfci=sfcf${FH3}.$affix
+    logi=logf${FH3}
+    pgbi=GFSPRS.GrbF${FH2}
+    flxi=GFSFLX.GrbF${FH2}
+    atmo=$memdir/${CDUMP}.t${cyc}z.atmf${FH3}.$affix
+    sfco=$memdir/${CDUMP}.t${cyc}z.sfcf${FH3}.$affix
+    logo=$memdir/${CDUMP}.t${cyc}z.logf${FH3}.txt
+    pgbo=$memdir/${CDUMP}.t${cyc}z.master.grb2f${FH3}
+    flxo=$memdir/${CDUMP}.t${cyc}z.sfluxgrbf${FH3}.grib2
+    eval $NLN $atmo $atmi
+    eval $NLN $sfco $sfci
+    eval $NLN $logo $logi
+    if [ $WRITE_DOPOST = ".true." ]; then
+      eval $NLN $pgbo $pgbi
+      eval $NLN $flxo $flxi
+    fi
+    FHINC=$FHOUT
+    if [ $FHMAX_HF -gt 0 -a $FHOUT_HF -gt 0 -a $fhr -lt $FHMAX_HF ]; then
+      FHINC=$FHOUT_HF
+    fi
+    fhr=$((fhr+FHINC))
+  done
+else
+  for n in $(seq 1 $ntiles); do
+    eval $NLN nggps2d.tile${n}.nc       $memdir/nggps2d.tile${n}.nc
+    eval $NLN nggps3d.tile${n}.nc       $memdir/nggps3d.tile${n}.nc
+    eval $NLN grid_spec.tile${n}.nc     $memdir/grid_spec.tile${n}.nc
+    eval $NLN atmos_static.tile${n}.nc  $memdir/atmos_static.tile${n}.nc
+    eval $NLN atmos_4xdaily.tile${n}.nc $memdir/atmos_4xdaily.tile${n}.nc
+  done
+fi
+
+# Copy namelist file
+$NCP input.nml $memdir
+
+#------------------------------------------------------------------
+# run the executable
+
+$NCP $FCSTEXECDIR/$FCSTEXEC $DATA/.
+export OMP_NUM_THREADS=$NTHREADS_FV3
+$APRUN_FV3 $DATA/$FCSTEXEC 1>&1 2>&2
+export ERR=$?
+export err=$ERR
+$ERRSCRIPT || exit $err
+
+#------------------------------------------------------------------
+if [ $SEND = "YES" ]; then
+  # Copy model restart files
+  cd $RSTDIR_TMP
+  #mkdir -p $memdir/RESTART
+
+  # Only save restarts at single time in RESTART directory
+  # Either at restart_interval or at end of the forecast
+  if [ $restart_interval -eq 0 -o $restart_interval -eq $FHMAX ]; then
+
+    # Add time-stamp to restart files at FHMAX
+    RDATE=$($NDATE +$FHMAX $CDATE)
+    rPDY=$(echo $RDATE | cut -c1-8)
+    rcyc=$(echo $RDATE | cut -c9-10)
+    for file in $(ls * | grep -v 0000); do
+      $NMV $file ${rPDY}.${rcyc}0000.$file
+      #$NCP ${rPDY}.${rcyc}0000.$file $memdir/RESTART/${rPDY}.${rcyc}0000.$file #lzhang
+    done
+    cd $memdir/
+    $NLN RERUN_RESTART  RESTART 
+  #  $NLN $memdir/RESTART  $RSTDIR_TMP
+   
+
+  else
+    mkdir -p ../RESTART
+    # time-stamp exists at restart_interval time, just copy
+    RDATE=$($NDATE +$restart_interval $CDATE)
+    rPDY=$(echo $RDATE | cut -c1-8)
+    rcyc=$(echo $RDATE | cut -c9-10)
+    for file in ${rPDY}.${rcyc}0000.* ; do
+      $NMV $file $memdir/RESTART/$file
+    done
+    cd $memdir/
+    rm -rf RERUN_RESTART
+    $NLN RESTART RERUN_RESTART
+  fi
+
+
+
+  # Copy gdas and enkf member restart files
+  if [ $CDUMP = "gdas" -a $rst_invt1 -gt 0 ]; then
+    cd $DATA/RESTART
+    mkdir -p $memdir/RESTART
+    for rst_int in $restart_interval ; do
+     if [ $rst_int -ge 0 ]; then
+       RDATE=$($NDATE +$rst_int $CDATE)
+       rPDY=$(echo $RDATE | cut -c1-8)
+       rcyc=$(echo $RDATE | cut -c9-10)
+       for file in $(ls ${rPDY}.${rcyc}0000.*) ; do
+         $NCP $file $memdir/RESTART/$file
+       done
+     fi
+    done
+    if [ $DOIAU = "YES" ] || [ $DOIAU_coldstart = "YES" ]; then
+      # if IAU is on, save restart at start of IAU window
+      rst_iau=$(( ${IAU_OFFSET} - (${IAU_DELTHRS}/2) ))
+      if [ $rst_iau -lt 0 ];then
+         rst_iau=$(( (${IAU_DELTHRS}) - ${IAU_OFFSET} ))
+      fi
+      RDATE=$($NDATE +$rst_iau $CDATE)
+      rPDY=$(echo $RDATE | cut -c1-8)
+      rcyc=$(echo $RDATE | cut -c9-10)
+      for file in $(ls ${rPDY}.${rcyc}0000.*) ; do
+         $NCP $file $memdir/RESTART/$file
+      done
+    fi
+  fi
+fi
+
+#------------------------------------------------------------------
+# Clean up before leaving
+if [ $mkdata = "YES" ]; then rm -rf $DATA; fi
+
+#------------------------------------------------------------------
+set +x
+if [ $VERBOSE = "YES" ] ; then
+  echo $(date) EXITING $0 with return code $err >&2
+fi
+exit 0

--- a/sorc/build_fv3_ccpp_chem.sh
+++ b/sorc/build_fv3_ccpp_chem.sh
@@ -25,6 +25,6 @@ cd tests/
 #./compile.sh  "$target" "CCPP=Y 32BIT=Y STATIC=Y DEBUG=Y SUITES=FV3_GFS_v15" 2 NO NO  #minimum 
 #./compile.sh "$target" "CCPP=Y 32BIT=Y STATIC=Y SUITES=FV3_GFS_v15" 2 YES YES  #clean everything and recompile
 #./compile.sh "$target" "CCPP=Y 32BIT=Y STATIC=Y SUITES=FV3_GFS_2017_gfdlmp_gsd_chem" 2 YES YES  #clean everything and recompile
-./compile.sh "$target" "CCPP=Y 32BIT=Y STATIC=Y SUITES=FV3_GFS_v15_gsd_chem" 2 YES YES  #clean everything and recompile
+./compile.sh "$target" "CCPP=Y 32BIT=Y STATIC=Y SUITES=FV3_GFS_v15,FV3_GFS_v15_gsd_chem" 2 YES YES  #clean everything and recompile
 #./compile.sh "$target" "REPRO=Y CCPP=Y STATIC=Y SUITES=FV3_GFS_v15" 2 YES YES  #clean everything and recompile (regression test way)
 mv -f fv3_2.exe ../NEMS/exe/global_fv3gfs_ccpp.x


### PR DESCRIPTION
- added linking to FV3-Chem regrid directory in calcinc_gfsv16.sh
- added calcinc_gfsv16.sh-retro file
- check to see if $DATA directory exists in calcinc v16 scripts; if not, create it
- added CCPP-C384
  -- new experiment setup script, ush/rocoto/rt-ccpp_c384.sh
  -- new realtime experiment directory for CCPP-C384, FV3GFSwfm/rt_ccpp_c384
  -- new field table, parm/parm_fv3diag/field_table_gfdl_gsd
  -- new global forecast script, exglobal_fcst_nemsfv3gfs_nochem.sh
  -- add FV3_GFS_v15 suite when compiling fv3_ccpp_chem