### PR TITLE
Pygraf fixes for Rocky 8

### DIFF
--- a/FV3GFSwfm/rt_v17p8_ugwpv1_mynn/rt_pygraf_global_ugwpv1_mynn.xml
+++ b/FV3GFSwfm/rt_v17p8_ugwpv1_mynn/rt_pygraf_global_ugwpv1_mynn.xml
@@ -10,7 +10,7 @@
 	<!ENTITY FCST_LENGTH "120">
 
 	<!-- Experiment parameters such as starting, ending dates -->
-	<!ENTITY SDATE    "202403210000">
+	<!ENTITY SDATE    "202403290000">
 	<!ENTITY EDATE    "203403200000">
 	<!ENTITY INTERVAL "24:00:00">
 
@@ -24,7 +24,7 @@
 	<!-- Experiment related directories -->
 	<!ENTITY EXPDIR "&HOMEgfs;/FV3GFSwfm/&PSLOT;">
 	<!ENTITY ROTDIR "&HOMEgfs;/FV3GFSrun/&PSLOT;">
-	<!ENTITY PYGRAFDIR "/scratch1/BMC/gsd-fv3/rtruns/pygraf">
+	<!ENTITY PYGRAFDIR "/scratch1/BMC/gsd-fv3/exp/pygraf">
 
 	<!-- Machine related entities -->
 	<!ENTITY ACCOUNT    "gsd-fv3">

--- a/FV3GFSwfm/rt_v17p8_ugwpv1_mynn/rt_v17p8_ugwpv1_mynn.xml
+++ b/FV3GFSwfm/rt_v17p8_ugwpv1_mynn/rt_v17p8_ugwpv1_mynn.xml
@@ -84,7 +84,7 @@
 	<account>gsd-fv3</account>
 	<queue>batch</queue>
 	<partition>hera</partition>
-	<walltime>05:30:00</walltime>
+	<walltime>05:50:00</walltime>
 <!--	<nodes>101:ppn=40:tpp=1</nodes> -->    <!-- 16x16, 2th, 2wg, 40wt -->
 	<nodes>56:ppn=40:tpp=1</nodes>         <!-- 12x12, 2th, 1wg, 40wt -->
         <native>&NATIVE_STR;</native>

--- a/FV3GFSwfm/rt_v17p8_ugwpv1_mynn/test_pygraf.xml
+++ b/FV3GFSwfm/rt_v17p8_ugwpv1_mynn/test_pygraf.xml
@@ -10,8 +10,8 @@
 	<!ENTITY FCST_LENGTH "120">
 
 	<!-- Experiment parameters such as starting, ending dates -->
-	<!ENTITY SDATE    "202403210000">
-	<!ENTITY EDATE    "202403210000">
+	<!ENTITY SDATE    "202403270000">
+	<!ENTITY EDATE    "202403270000">
 	<!ENTITY INTERVAL "24:00:00">
 
 	<!-- Run Envrionment -->
@@ -24,8 +24,8 @@
 	<!-- Experiment related directories -->
 	<!ENTITY EXPDIR "&HOMEgfs;/FV3GFSwfm/&PSLOT;">
 	<!ENTITY ROTDIR "&HOMEgfs;/FV3GFSrun/&PSLOT;">
-	<!ENTITY PYGRAFDIR "/scratch1/BMC/gsd-fv3/exp/pygraf">
-	<!ENTITY PYGRAFDIR "/scratch1/BMC/gsd-fv3/rtruns/pygraf">
+	<!ENTITY PYGRAFDIR "/scratch1/BMC/gsd-fv3/exp/pygraf">                   <!-- updated with latest for Rocky8 -->
+	<!ENTITY PYGRAFDIR "/scratch1/BMC/gsd-fv3/rtruns/pygraf">                <!-- running under CentOs7 -->
 
 	<!-- Machine related entities -->
 	<!ENTITY ACCOUNT    "gsd-fv3">
@@ -58,13 +58,15 @@
 	<!-- Define the cycles -->
 	<cycledef group="gfs">&SDATE; &EDATE; &INTERVAL;</cycledef>
 
+<!--
+
   <metatask name="remapgrib" throttle="58">
 
     <var name="fcst"> 0 6 12 18 24 30 36 42 48 54 60 66 72 78 84 90 96 102 108 114 120 </var>
     <var name="T"> 000 006 012 018 024 030 036 042 048 054 060 066 072 078 084 090 096 102 108 114 120 </var>
 
     <task name="remapgrib_#T#" cycledefs="gfs" maxtries="4">
-        <command>&JOBS_DIR;/remapgrib.ksh</command>
+        <command>&JOBS_DIR;/remapgrib.sh</command>
         <account>&ACCOUNT;</account>
         <cores>1</cores>
         <walltime>00:35:00</walltime>
@@ -83,12 +85,18 @@
     </task>
 
   </metatask>
+-->
 
   <metatask>
 
+<!--
     <var name="GRID_ID">full 242 130 201</var>
     <var name="TILESET">full,Africa,Beijing,Cambodia,EPacific,Europe,Taiwan,WAtlantic,WPacific AK,AKZoom,AKZoom2 CONUS,NC,NE,NW,SC,SE,SW NHemi</var>
     <var name="IMGFILE">global.yml globalAK.yml globalCONUS.yml globalNHemi.yml</var>
+-->
+    <var name="GRID_ID">242 </var>
+    <var name="TILESET">AK,AKZoom,AKZoom2 </var>
+    <var name="IMGFILE">globalAK.yml </var>
 
     <task name="gfspygraf_#GRID_ID#" cycledefs="gfs" maxtries="&MAXTRIES;">
   
@@ -118,15 +126,15 @@
           <native>--exclusive</native>
           <jobname><cyclestr>FV3GFS_python_maps_#GRID_ID#_@H_ugwpv1_mynn</cyclestr></jobname>
           <join><cyclestr>&ROTDIR;/logs/@Y@m@d@H/python_@Y@m@d@H00_maps_#GRID_ID#_0-6-&FCST_LENGTH;.log</cyclestr></join>
-  
+ <!-- 
     <dependency>
-<!--        <or>
+        <or>
           <timedep><cyclestr offset="030:00:00">@Y@m@d@H@M00</cyclestr></timedep>
           <metataskdep metatask="remapgrib"/>
         </or>
--->
           <metataskdep metatask="remapgrib"/>
     </dependency>
+-->
   
     </task>
 

--- a/FV3GFSwfm/rt_v17p8_ugwpv1_mynn/v17p8_ugwpv1_mynn.xml
+++ b/FV3GFSwfm/rt_v17p8_ugwpv1_mynn/v17p8_ugwpv1_mynn.xml
@@ -84,7 +84,7 @@
 	<account>gsd-fv3-dev</account>
 	<queue>batch</queue>
 	<partition>hera</partition>
-	<walltime>05:10:00</walltime>
+	<walltime>05:50:00</walltime>
 <!--	<nodes>101:ppn=40:tpp=1</nodes> -->    <!-- 16x16, 2th, 2wg, 40wt -->
 	<nodes>56:ppn=40:tpp=1</nodes>         <!-- 12x12, 2th, 1wg, 40wt -->
         <native>&NATIVE_STR;</native>

--- a/jobs/rocoto/remapgrib.sh
+++ b/jobs/rocoto/remapgrib.sh
@@ -4,9 +4,7 @@
 #    236 201 244 130 224 242
 
 # initialize
-module load gnu/13.2.0
-module load netcdf/4.7.0 
-module load wgrib2/3.1.2_ncep
+module load gnu/13.2.0 intel/2023.2.0 netcdf/4.7.0 wgrib2/3.1.2_ncep
 module list
 ECHO=echo
 MKDIR=mkdir


### PR DESCRIPTION
From @jkhender:

Changes for running pygraf under Rocky

       - call remapgrib.sh due to wgrib2 change
       - updated checkout for pygraf is in test directory, /scratch1/BMC/gsd-fv3/exp/pygraf

Update walltime to 5:50 for gfsfcst task